### PR TITLE
Feature/nxl 8173680838 geobox sector select

### DIFF
--- a/src/components/elements/SectorSelector/SectorSelector.module.scss
+++ b/src/components/elements/SectorSelector/SectorSelector.module.scss
@@ -35,6 +35,18 @@
 		stroke-width: 2px;
 	}
 }
+.geoboxTrigger {
+	cursor: pointer;
+	fill: transparent;
+}
+.geobox {
+	fill: var(--color-blue3);
+	stroke: var(--color-blue4);
+	opacity: 0;
+	stroke-width: 2px;
+	pointer-events: none;
+	transition: ease all 0.25s;
+}
 
 .tooltip {
 	pointer-events: none;

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -5,19 +5,15 @@ import Select from '../Select/Select'
 import SectorSelector from './SectorSelector'
 import { regions } from './regions'
 
-const pointSectors = Object.entries(STATE_SURFACE_SECTORS)
-	.slice(11, 14)
-	.map(([sector, sectorObj]) => ({
-		id: sector,
-		...sectorObj,
-	}))
+const pointSectors = Object.entries(STATE_SURFACE_SECTORS).map(([sector, sectorObj]) => ({
+	id: sector,
+	...sectorObj,
+}))
 
-const geoboxSectors = Object.entries(LARGE_SURFACE_SECTORS)
-	.slice(6, 9)
-	.map(([sector, sectorObj]) => ({
-		id: sector,
-		...sectorObj,
-	}))
+const geoboxSectors = Object.entries(LARGE_SURFACE_SECTORS).map(([sector, sectorObj]) => ({
+	id: sector,
+	...sectorObj,
+}))
 
 const sectorOptions = [...pointSectors, ...geoboxSectors]
 
@@ -73,7 +69,19 @@ const TemplatePlain: StoryFn<typeof SectorSelector> = (args) => {
 
 export const Default = TemplatePlain.bind({})
 Default.args = {
-	sectors: sectorOptions,
+	sectors: pointSectors,
+	sector: '',
+	d3config: {
+		width: 1000,
+		height: 600,
+		rotate: regions.CONUS.rotate,
+		scale: regions.CONUS.scale,
+	},
+}
+
+export const GeoboxSectors = TemplateSelect.bind({})
+GeoboxSectors.args = {
+	sectors: geoboxSectors,
 	sector: '',
 	d3config: {
 		width: 1000,
@@ -85,7 +93,7 @@ Default.args = {
 
 export const RegionSelection = TemplateSelect.bind({})
 RegionSelection.args = {
-	sectors: sectorOptions,
+	sectors: pointSectors,
 	sector: '',
 	d3config: {
 		width: 1000,

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -1,9 +1,25 @@
+import { LARGE_SURFACE_SECTORS, STATE_SURFACE_SECTORS } from '@/data/analysis/surface/sectors'
 import { StoryFn } from '@storybook/react'
 import { useState } from 'react'
 import Select from '../Select/Select'
 import SectorSelector from './SectorSelector'
-import { nexradSites } from './nexradSites'
 import { regions } from './regions'
+
+const pointSectors = Object.entries(STATE_SURFACE_SECTORS)
+	.slice(0, 3)
+	.map(([sector, sectorObj]) => ({
+		id: sector,
+		...sectorObj,
+	}))
+
+const geoboxSectors = Object.entries(LARGE_SURFACE_SECTORS)
+	.slice(0, 3)
+	.map(([sector, sectorObj]) => ({
+		id: sector,
+		...sectorObj,
+	}))
+
+const sectorOptions = Object.fromEntries([pointSectors, geoboxSectors])
 
 export default {
 	title: 'Components/SectorSelector',
@@ -55,7 +71,7 @@ const TemplatePlain: StoryFn<typeof SectorSelector> = (args) => {
 
 export const Default = TemplatePlain.bind({})
 Default.args = {
-	sectors: nexradSites,
+	sectors: sectorOptions,
 	sector: '',
 	d3config: {
 		width: 1000,
@@ -67,7 +83,7 @@ Default.args = {
 
 export const RegionSelection = TemplateSelect.bind({})
 RegionSelection.args = {
-	sectors: nexradSites,
+	sectors: sectorOptions,
 	sector: '',
 	d3config: {
 		width: 1000,

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -15,10 +15,6 @@ const geoboxSectors = Object.entries(LARGE_SURFACE_SECTORS).map(([sector, sector
 	...sectorObj,
 }))
 
-const sectorOptions = [...pointSectors, ...geoboxSectors]
-
-console.log('sector options', sectorOptions)
-
 export default {
 	title: 'Components/SectorSelector',
 	component: SectorSelector,

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -6,20 +6,22 @@ import SectorSelector from './SectorSelector'
 import { regions } from './regions'
 
 const pointSectors = Object.entries(STATE_SURFACE_SECTORS)
-	.slice(0, 3)
+	.slice(11, 14)
 	.map(([sector, sectorObj]) => ({
 		id: sector,
 		...sectorObj,
 	}))
 
 const geoboxSectors = Object.entries(LARGE_SURFACE_SECTORS)
-	.slice(0, 3)
+	.slice(6, 9)
 	.map(([sector, sectorObj]) => ({
 		id: sector,
 		...sectorObj,
 	}))
 
-const sectorOptions = Object.fromEntries([pointSectors, geoboxSectors])
+const sectorOptions = [...pointSectors, ...geoboxSectors]
+
+console.log('sector options', sectorOptions)
 
 export default {
 	title: 'Components/SectorSelector',

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -56,11 +56,22 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 		statesGroup.selectAll('path.statePath').data(statesJson.features).enter().append('path').attr('d', path).attr('class', styles.statePath)
 
 		// Filter sectors that are visible in this view of the projection
-		const filteredSectors = sectors.filter((d) => d3.geoDistance(center, d.coordinates) < Math.PI / 2)
+		// const filteredSectors = sectors.filter((d) => d3.geoDistance(center, d.coordinates) < Math.PI / 2)
 
 		// Split the sectors by type
-		const pointSectors = filteredSectors.filter((d) => d.type === 'Point')
-		const geoboxSectors = filteredSectors.filter((d) => d.type === 'Geobox')
+		const pointSectors = sectors.filter((d) => {
+			let isVisible = false
+			isVisible = d.type === 'Point' ? d3.geoDistance(center, d.coordinates) < Math.PI / 2 : false
+			return d.type === 'Point' && isVisible
+		})
+		const geoboxSectors = sectors.filter((d) => {
+			let isVisible = false
+			if (d.type === 'Geobox') {
+				const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
+				isVisible = d3.geoDistance(center, d3.geoCentroid(geobox)) < Math.PI / 2
+			}
+			return d.type === 'Geobox' && isVisible
+		})
 
 		// Draw Point sectors and their mouse triggers
 		if (pointSectors.length > 0) {
@@ -80,7 +91,7 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 						.attr('x', projection(d.coordinates)[0])
 						.attr('y', projection(d.coordinates)[1] - 10)
 						.attr('class', styles.tooltip)
-						.text(d.id)
+						.text(d.name)
 				})
 				.on('mouseout', (_event) => {
 					d3.select(_event.currentTarget).attr('r', 10)
@@ -105,28 +116,52 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 		if (geoboxSectors.length > 0) {
 			const geoboxGroup = svg.append('g')
 
+			// Draw the visible geobox outlines
+			geoboxGroup
+				.selectAll('path.geobox')
+				.data(geoboxSectors)
+				.enter()
+				.append('path')
+				.attr('d', (d) => {
+					const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
+					return path(geobox)
+				})
+				.attr('class', (d) => `${styles.geobox} ${d.id}`)
+
 			// Draw the invisible geobox mouse trigger
 			geoboxGroup
 				.selectAll('path.geoboxTrigger')
 				.data(geoboxSectors)
 				.enter()
 				.append('circle')
-				.attr('cx', (d) => projection(d3.geoCentroid(d.coordinates))[0])
-				.attr('cy', (d) => projection(d3.geoCentroid(d.coordinates))[1])
+				.attr('cx', (d) => {
+					const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
+					return projection(d3.geoCentroid(geobox))[0]
+				})
+				.attr('cy', (d) => {
+					const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
+					return projection(d3.geoCentroid(geobox))[1]
+				})
 				.attr('r', 25)
 				.attr('class', styles.geoboxTrigger)
+				.attr('id', (d) => d.id)
 				.on('mouseover', (_event, d) => {
+					const geoboxOutline = d3.geoGraticule().extentMajor(d.coordinates).outline()
 					// draw the visible geobox
-					svg.append('path').attr('d', d3.geoGraticule().extentMajor(d.coordinates).outline()).attr('class', styles.geobox)
+					d3.select(`.${styles.geobox}.${d.id}`).attr('style', 'opacity: 0.5')
 					// draw the tooltip
 					svg.append('text')
-						.attr('x', projection(d3.geoCentroid(d.coordinates))[0])
-						.attr('y', projection(d3.geoCentroid(d.coordinates))[1] - 10)
+						.attr('x', () => {
+							return projection(d3.geoCentroid(geoboxOutline))[0]
+						})
+						.attr('y', () => {
+							return projection(d3.geoCentroid(geoboxOutline))[1] - 10
+						})
 						.attr('class', styles.tooltip)
 						.text(d.name)
 				})
-				.on('mouseout', () => {
-					svg.selectAll(`.${styles.geobox}`).remove()
+				.on('mouseout', (d) => {
+					d3.select(`.${styles.geobox}.${d.target.id}`).attr('style', 'opacity: 0')
 					svg.selectAll(`.${styles.tooltip}`).remove()
 				})
 				.on('click', (_event, d) => {
@@ -139,8 +174,14 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				.data(geoboxSectors)
 				.enter()
 				.append('circle')
-				.attr('cx', (d) => projection(d3.geoCentroid(d.coordinates))[0])
-				.attr('cy', (d) => projection(d3.geoCentroid(d.coordinates))[1])
+				.attr('cx', (d) => {
+					const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
+					return projection(d3.geoCentroid(geobox))[0]
+				})
+				.attr('cy', (d) => {
+					const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
+					return projection(d3.geoCentroid(geobox))[1]
+				})
 				.attr('r', 5)
 				.attr('class', styles.point)
 		}

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -16,8 +16,8 @@ export type ISectorSelectorProps = {
 	sectors: {
 		id: string
 		name: string
-		type: string
-		coordinates: [number, number]
+		type: 'Point' | 'Geobox'
+		coordinates: [number, number] | [[number, number], [number, number]]
 	}[]
 	sector: string
 	onChange: (id: string) => void
@@ -54,44 +54,96 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 
 		const statesGroup = svg.append('g')
 		statesGroup.selectAll('path.statePath').data(statesJson.features).enter().append('path').attr('d', path).attr('class', styles.statePath)
-		// Draw the circles
-		const pointsGroup = svg.append('g')
 
-		// Draw interactive regions
-		pointsGroup
-			.selectAll('circle.pointRegion')
-			.data(sectors.filter((d) => d3.geoDistance(center, d.coordinates) < Math.PI / 2))
-			.enter()
-			.append('circle')
-			.attr('cx', (d) => projection(d.coordinates)[0])
-			.attr('cy', (d) => projection(d.coordinates)[1])
-			.attr('r', 10)
-			.attr('class', styles.pointRegion)
-			.on('mouseover', (_event, d) => {
-				d3.select(_event.currentTarget).attr('r', 25)
-				svg.append('text')
-					.attr('x', projection(d.coordinates)[0])
-					.attr('y', projection(d.coordinates)[1] - 10)
-					.attr('class', styles.tooltip)
-					.text(d.id)
-			})
-			.on('mouseout', (_event) => {
-				d3.select(_event.currentTarget).attr('r', 10)
-				svg.selectAll(`.${styles.tooltip}`).remove()
-			})
-			.on('click', (_event, d) => {
-				onChange(d.id)
-			})
+		// Filter sectors that are visible in this view of the projection
+		const filteredSectors = sectors.filter((d) => d3.geoDistance(center, d.coordinates) < Math.PI / 2)
 
-		pointsGroup
-			.selectAll('circle.point')
-			.data(sectors.filter((d) => d3.geoDistance(center, d.coordinates) < Math.PI / 2))
-			.enter()
-			.append('circle')
-			.attr('cx', (d) => projection(d.coordinates)[0])
-			.attr('cy', (d) => projection(d.coordinates)[1])
-			.attr('r', 5)
-			.attr('class', styles.point)
+		// Split the sectors by type
+		const pointSectors = filteredSectors.filter((d) => d.type === 'Point')
+		const geoboxSectors = filteredSectors.filter((d) => d.type === 'Geobox')
+
+		// Draw Point sectors and their mouse triggers
+		if (pointSectors.length > 0) {
+			const pointsGroup = svg.append('g')
+			pointsGroup
+				.selectAll('circle.pointRegion')
+				.data(pointSectors)
+				.enter()
+				.append('circle')
+				.attr('cx', (d) => projection(d.coordinates)[0])
+				.attr('cy', (d) => projection(d.coordinates)[1])
+				.attr('r', 10)
+				.attr('class', styles.pointRegion)
+				.on('mouseover', (_event, d) => {
+					d3.select(_event.currentTarget).attr('r', 25)
+					svg.append('text')
+						.attr('x', projection(d.coordinates)[0])
+						.attr('y', projection(d.coordinates)[1] - 10)
+						.attr('class', styles.tooltip)
+						.text(d.id)
+				})
+				.on('mouseout', (_event) => {
+					d3.select(_event.currentTarget).attr('r', 10)
+					svg.selectAll(`.${styles.tooltip}`).remove()
+				})
+				.on('click', (_event, d) => {
+					onChange(d.id)
+				})
+
+			pointsGroup
+				.selectAll('circle.point')
+				.data(pointSectors)
+				.enter()
+				.append('circle')
+				.attr('cx', (d) => projection(d.coordinates)[0])
+				.attr('cy', (d) => projection(d.coordinates)[1])
+				.attr('r', 5)
+				.attr('class', styles.point)
+		}
+
+		// Draw Geobox sectors and their mouse triggers
+		if (geoboxSectors.length > 0) {
+			const geoboxGroup = svg.append('g')
+
+			// Draw the invisible geobox mouse trigger
+			geoboxGroup
+				.selectAll('path.geoboxTrigger')
+				.data(geoboxSectors)
+				.enter()
+				.append('circle')
+				.attr('cx', (d) => projection(d3.geoCentroid(d.coordinates))[0])
+				.attr('cy', (d) => projection(d3.geoCentroid(d.coordinates))[1])
+				.attr('r', 25)
+				.attr('class', styles.geoboxTrigger)
+				.on('mouseover', (_event, d) => {
+					// draw the visible geobox
+					svg.append('path').attr('d', d3.geoGraticule().extentMajor(d.coordinates).outline()).attr('class', styles.geobox)
+					// draw the tooltip
+					svg.append('text')
+						.attr('x', projection(d3.geoCentroid(d.coordinates))[0])
+						.attr('y', projection(d3.geoCentroid(d.coordinates))[1] - 10)
+						.attr('class', styles.tooltip)
+						.text(d.name)
+				})
+				.on('mouseout', () => {
+					svg.selectAll(`.${styles.geobox}`).remove()
+					svg.selectAll(`.${styles.tooltip}`).remove()
+				})
+				.on('click', (_event, d) => {
+					onChange(d.id)
+				})
+
+			// Draw the geobox center point
+			geoboxGroup
+				.selectAll('circle.point')
+				.data(geoboxSectors)
+				.enter()
+				.append('circle')
+				.attr('cx', (d) => projection(d3.geoCentroid(d.coordinates))[0])
+				.attr('cy', (d) => projection(d3.geoCentroid(d.coordinates))[1])
+				.attr('r', 5)
+				.attr('class', styles.point)
+		}
 	}, [sectors, onChange, sector, d3config])
 
 	if (!d3config) return <></>


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 8173680838

## Description
Added support for a new type of sector feature called a Geobox. An outline formed by graticules to display a sector highlight representative of large spatial sectors rather than Point sectors (sites). Maintained support of mouseover and tooltip effects similar to point. Lowered fill opacity, cosmetic preference, was overbearing at 80%.

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run storybook` under SectorSelector - checked for build errors with `npm run build`

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):
![geobox](https://github.com/user-attachments/assets/7fd1e08a-aca0-450a-b970-12fbb341b82f)
![point](https://github.com/user-attachments/assets/c42a23b5-5581-4257-8fd4-fbb9d57e79af)


## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
