### PR TITLE
Working Line Sector Story

### DIFF
--- a/src/components/elements/SectorSelector/SectorSelector.module.scss
+++ b/src/components/elements/SectorSelector/SectorSelector.module.scss
@@ -1,6 +1,7 @@
 .SectorSelector {
 	width: 100%;
 	height: 100%;
+	position: relative;
 }
 .globe {
 	fill: var(--color-blue1-blue2);
@@ -48,21 +49,48 @@
 	pointer-events: none;
 	transition: ease all 0.25s;
 }
+.lineTrigger {
+	cursor: pointer;
+	fill: none;
+	stroke: transparent;
+	stroke-width: 40px;
+}
 .line {
 	fill: none;
-	stroke: var(--color-blue4);
+	stroke: var(--color-grey16-grey2);
 	stroke-width: 3px;
 	transition: ease all 0.25s;
-	&:hover {
-		cursor: pointer;
-		stroke-width: 6px;
-	}
+	pointer-events: none;
+}
+.lineHover {
+	fill: none;
+	stroke: var(--color-blue4);
+	stroke-width: 6px;
+	transition: ease all 0.25s;
+	pointer-events: none;
 }
 .tooltip {
 	pointer-events: none;
 	user-select: none;
 	fill: white;
+	background: #333;
+	border: 1px solid #999;
+	padding: 2px 5px;
 	font-size: 10px;
 	text-anchor: middle;
+	position: absolute;
 	transition: ease all 0.25s;
+	z-index: 100;
+}
+.lineName {
+	pointer-events: none;
+	user-select: none;
+	color: white;
+	background: #333;
+	border: 1px solid #999;
+	padding: 2px 5px;
+	font-size: 10px;
+	position: absolute;
+	transition: ease all 0.25s;
+	z-index: 100;
 }

--- a/src/components/elements/SectorSelector/SectorSelector.module.scss
+++ b/src/components/elements/SectorSelector/SectorSelector.module.scss
@@ -72,9 +72,7 @@
 .tooltip {
 	pointer-events: none;
 	user-select: none;
-	fill: white;
-	background: #333;
-	border: 1px solid #999;
+	fill: var(--color-grey18-grey2);
 	padding: 2px 5px;
 	font-size: 10px;
 	text-anchor: middle;
@@ -85,11 +83,11 @@
 .lineName {
 	pointer-events: none;
 	user-select: none;
+	font-size: 14px;
 	color: white;
 	background: #333;
 	border: 1px solid #999;
 	padding: 2px 5px;
-	font-size: 10px;
 	position: absolute;
 	transition: ease all 0.25s;
 	z-index: 100;

--- a/src/components/elements/SectorSelector/SectorSelector.module.scss
+++ b/src/components/elements/SectorSelector/SectorSelector.module.scss
@@ -17,7 +17,8 @@
 	stroke: var(--color-white-grey18);
 	stroke-width: 1px;
 }
-.point {
+.point,
+.lineEnd {
 	fill: white;
 	stroke: black;
 	stroke-width: 2px;
@@ -47,7 +48,16 @@
 	pointer-events: none;
 	transition: ease all 0.25s;
 }
-
+.line {
+	fill: none;
+	stroke: var(--color-blue4);
+	stroke-width: 3px;
+	transition: ease all 0.25s;
+	&:hover {
+		cursor: pointer;
+		stroke-width: 6px;
+	}
+}
 .tooltip {
 	pointer-events: none;
 	user-select: none;

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -1,3 +1,4 @@
+import { ALL_CROSS_SECTORS } from '@/data/analysis/cross-sectional-analysis/sectors'
 import { LARGE_SURFACE_SECTORS, STATE_SURFACE_SECTORS } from '@/data/analysis/surface/sectors'
 import { StoryFn } from '@storybook/react'
 import { useState } from 'react'
@@ -11,6 +12,11 @@ const pointSectors = Object.entries(STATE_SURFACE_SECTORS).map(([sector, sectorO
 }))
 
 const geoboxSectors = Object.entries(LARGE_SURFACE_SECTORS).map(([sector, sectorObj]) => ({
+	id: sector,
+	...sectorObj,
+}))
+
+const crossSectors = Object.entries(ALL_CROSS_SECTORS).map(([sector, sectorObj]) => ({
 	id: sector,
 	...sectorObj,
 }))
@@ -78,6 +84,18 @@ Default.args = {
 export const GeoboxSectors = TemplateSelect.bind({})
 GeoboxSectors.args = {
 	sectors: geoboxSectors,
+	sector: '',
+	d3config: {
+		width: 1000,
+		height: 600,
+		rotate: regions.CONUS.rotate,
+		scale: regions.CONUS.scale,
+	},
+}
+
+export const CrossSectors = TemplateSelect.bind({})
+CrossSectors.args = {
+	sectors: crossSectors,
 	sector: '',
 	d3config: {
 		width: 1000,

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -16,7 +16,7 @@ export type ISectorSelectorProps = {
 	sectors: {
 		id: string
 		name: string
-		type: 'Point' | 'Geobox'
+		type: 'Point' | 'Geobox' | 'Line'
 		coordinates: [number, number] | [[number, number], [number, number]]
 	}[]
 	sector: string
@@ -72,6 +72,30 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 			}
 			return d.type === 'Geobox' && isVisible
 		})
+
+		const lineSectors = sectors.filter((d) => {
+			let isVisible = false
+			if (d.type === 'Line') {
+				const midpoint = d3.interpolate(d.coordinates[0], d.coordinates[1])(0.5)
+				isVisible = d3.geoDistance(center, midpoint) < Math.PI / 2
+			}
+			return d.type === 'Line' && isVisible
+		})
+
+		// Necessary data transformation to generate Line feature from endpoints
+		const arcFromCoordinates = (pointA, pointB) => {
+			const interpolation = d3.geoInterpolate(pointA, pointB)
+			const numPoints = 100
+			const arc = d3.range(numPoints).map((d) => interpolation(d / (numPoints - 1)))
+			const arcFeature = {
+				type: 'Feature',
+				geometry: {
+					type: 'LineString',
+					coordinates: arc,
+				},
+			}
+			return arcFeature
+		}
 
 		// Draw Point sectors and their mouse triggers
 		if (pointSectors.length > 0) {
@@ -184,6 +208,56 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				})
 				.attr('r', 5)
 				.attr('class', styles.point)
+		}
+
+		// Draw Line sectors and their mouse triggers
+		if (lineSectors.length > 0) {
+			const lineGroup = svg.append('g')
+
+			lineGroup
+				.selectAll('path.line')
+				.data(lineSectors)
+				.enter()
+				.append('path')
+				.attr('class', styles.line)
+				.attr('d', (d) => path(arcFromCoordinates(d.coordinates[0], d.coordinates[1])))
+				.on('mouseover', (_event, d) => {
+					svg.append('text')
+						.attr('x', projection(d.coordinates[0])[0])
+						.attr('y', projection(d.coordinates[0])[1] - 10)
+						.attr('class', styles.tooltip)
+						.text(d.label[0])
+					svg.append('text')
+						.attr('x', projection(d.coordinates[1])[0])
+						.attr('y', projection(d.coordinates[1])[1] - 10)
+						.attr('class', styles.tooltip)
+						.text(d.label[1])
+				})
+				.on('mouseout', () => {
+					svg.selectAll(`.${styles.tooltip}`).remove()
+				})
+				.on('click', (_event, d) => {
+					console.log(d.id)
+					onChange(d.id)
+				})
+			lineGroup
+				.selectAll('circle.lineEnd')
+				.data(lineSectors)
+				.enter()
+				.append('circle')
+				.attr('cx', (d) => projection(d.coordinates[0])[0])
+				.attr('cy', (d) => projection(d.coordinates[0])[1])
+				.attr('r', 5)
+				.attr('class', styles.lineEnd)
+			lineGroup
+				.selectAll('circle.lineEnd')
+				.data(lineSectors)
+				.enter()
+				.append('circle')
+				.attr('cx', (d) => projection(d.coordinates[1])[0])
+				.attr('cy', (d) => projection(d.coordinates[1])[1])
+				.attr('r', 5)
+				.attr('class', styles.lineEnd)
 		}
 	}, [sectors, onChange, sector, d3config])
 

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -214,14 +214,32 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 		if (lineSectors.length > 0) {
 			const lineGroup = svg.append('g')
 
+			// Draw the visible line paths
 			lineGroup
 				.selectAll('path.line')
 				.data(lineSectors)
 				.enter()
 				.append('path')
-				.attr('class', styles.line)
+				.attr('class', (d) => `${styles.line} ${d.id}`)
+				.attr('d', (d) => path(arcFromCoordinates(d.coordinates[0], d.coordinates[1])))
+
+			// Draw the invisible line triggers
+			lineGroup
+				.selectAll('path.lineTrigger')
+				.data(lineSectors)
+				.enter()
+				.append('path')
+				.attr('class', styles.lineTrigger)
 				.attr('d', (d) => path(arcFromCoordinates(d.coordinates[0], d.coordinates[1])))
 				.on('mouseover', (_event, d) => {
+					// name tooltip
+					const lineName = d3.select('body').append('div').attr('class', styles.lineName).text(d.name)
+					console.log(lineName)
+					svg.on('mousemove', (event) => {
+						lineName.style('left', `${event.clientX + 15}px`).style('top', `${event.clientY - 15}px`)
+					})
+
+					// endpoint tooltips
 					svg.append('text')
 						.attr('x', projection(d.coordinates[0])[0])
 						.attr('y', projection(d.coordinates[0])[1] - 10)
@@ -232,14 +250,22 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 						.attr('y', projection(d.coordinates[1])[1] - 10)
 						.attr('class', styles.tooltip)
 						.text(d.label[1])
+
+					// highlight the line
+					svg.select(`path.${d.id}`).attr('class', `${styles.lineHover} ${d.id}`)
 				})
-				.on('mouseout', () => {
+				.on('mouseout', (_event, d) => {
+					svg.selectAll(`path.${d.id}`).attr('class', `${styles.line} ${d.id}`)
 					svg.selectAll(`.${styles.tooltip}`).remove()
+					d3.selectAll(`.${styles.lineName}`).remove()
+					svg.on('mousemove', null)
 				})
 				.on('click', (_event, d) => {
 					console.log(d.id)
 					onChange(d.id)
 				})
+
+			// Draw the line start and end points
 			lineGroup
 				.selectAll('circle.lineEnd')
 				.data(lineSectors)

--- a/src/data/analysis/cross-sectional-analysis/sectors.ts
+++ b/src/data/analysis/cross-sectional-analysis/sectors.ts
@@ -12,6 +12,7 @@ const ALL_PRODUCTS = ['xsect']
 export const ALL_CROSS_SECTORS = {
 	[XSECT_SECTOR_DRT_BIS]: {
 		name: 'Del Rio, TX to Bismark, ND',
+		label: ['DRT', 'BIS'],
 		type: 'Line',
 		coordinates: [
 			[-100.9, 29.37],
@@ -21,6 +22,7 @@ export const ALL_CROSS_SECTORS = {
 	},
 	[XSECT_SECTOR_ABQ_BNA]: {
 		name: 'Albuquerque, NM to Nashville, TN',
+		label: ['ABQ', 'BNA'],
 		type: 'Line',
 		coordinates: [
 			[-106.6, 35.1],
@@ -30,6 +32,7 @@ export const ALL_CROSS_SECTORS = {
 	},
 	[XSECT_SECTOR_CRP_RIW]: {
 		name: 'Corpus Christi, TX to Riverton, WY',
+		label: ['CRP', 'RIW'],
 		type: 'Line',
 		coordinates: [
 			[-97.5, 27.77],
@@ -39,6 +42,7 @@ export const ALL_CROSS_SECTORS = {
 	},
 	[XSECT_SECTOR_DEN_ILN]: {
 		name: 'Denver, CO to Willmington, OH',
+		label: ['DEN', 'ILN'],
 		type: 'Line',
 		coordinates: [
 			[-104.67, 39.85],
@@ -48,6 +52,7 @@ export const ALL_CROSS_SECTORS = {
 	},
 	[XSECT_SECTOR_DRT_GRB]: {
 		name: 'Del Rio, TX to Green Bay, WI',
+		label: ['DRT', 'GRB'],
 		type: 'Line',
 		coordinates: [
 			[-100.9, 29.37],
@@ -57,6 +62,7 @@ export const ALL_CROSS_SECTORS = {
 	},
 	[XSECT_SECTOR_DRT_TLH]: {
 		name: 'Del Rio, TX to Tallahassee, FL',
+		label: ['DRT', 'TLH'],
 		type: 'Line',
 		coordinates: [
 			[-100.9, 29.37],
@@ -66,6 +72,7 @@ export const ALL_CROSS_SECTORS = {
 	},
 	[XSECT_SECTOR_RIW_DTX]: {
 		name: 'Riverton, WY to White Lake, MI',
+		label: ['RIW', 'DTX'],
 		type: 'Line',
 		coordinates: [
 			[-108.45, 43.06],
@@ -75,6 +82,7 @@ export const ALL_CROSS_SECTORS = {
 	},
 	[XSECT_SECTOR_SIL_GRB]: {
 		name: 'Slidell, LA to Green Bay, WI',
+		label: ['SIL', 'GRB'],
 		type: 'Line',
 		coordinates: [
 			[-89.82, 30.34],


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 8173627619

## Description
Added acceptance of new type of sectors "Line" to be used for cross-sectional analysis. Working demo in storybook where approach is to draw all lines at once with a hover effect. Opted for simple width increase, but could explore other visual dynamics.

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run storybook` to test component acceptance of sector definitions, plotting and styling.
'npm run build` to check for build errors

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):
![xsect](https://github.com/user-attachments/assets/27ea6ea0-733d-41c5-9524-287eaf86295c)

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
