### PR TITLE
Feature/nxl 8173647468 sector select dot styles

### DIFF
--- a/src/components/elements/SectorSelector/SectorSelector.module.scss
+++ b/src/components/elements/SectorSelector/SectorSelector.module.scss
@@ -18,9 +18,14 @@
 	stroke: var(--color-white-grey18);
 	stroke-width: 1px;
 }
-.point,
-.lineEnd {
+.point {
 	fill: white;
+	stroke: black;
+	stroke-width: 2px;
+	pointer-events: none;
+	user-select: none;
+}
+.lineEnd {
 	stroke: black;
 	stroke-width: 2px;
 	pointer-events: none;

--- a/src/components/elements/SectorSelector/SectorSelector.module.scss
+++ b/src/components/elements/SectorSelector/SectorSelector.module.scss
@@ -19,13 +19,6 @@
 	stroke-width: 1px;
 }
 .point {
-	fill: white;
-	stroke: black;
-	stroke-width: 2px;
-	pointer-events: none;
-	user-select: none;
-}
-.lineEnd {
 	stroke: black;
 	stroke-width: 2px;
 	pointer-events: none;

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -25,20 +25,20 @@ const crossSectors = Object.entries(ALL_CROSS_SECTORS).map(([sector, sectorObj])
 const regionOptions = Object.keys(regions).map((region) => {
 	return { value: regions[region].id, label: regions[region].label }
 })
-console.log(regionOptions)
 
-const dotColorOptions = Object.keys(DotColor).map((color) => ({
-	value: DotColor[color as keyof typeof DotColor],
-	label: color,
-}))
+const dotColorOptions = Object.keys(DotColor).map((color) => {
+	return {
+		value: DotColor[color as keyof typeof DotColor],
+		label: color,
+	}
+})
 
-const dotShapeOptions = Object.keys(DotShape).map((shape) => ({
-	value: DotShape[shape as keyof typeof DotShape],
-	label: shape,
-}))
-
-console.log(dotColorOptions.find((color) => color.value === DotColor.White))
-console.log(dotShapeOptions)
+const dotShapeOptions = Object.keys(DotShape).map((shape) => {
+	return {
+		value: DotShape[shape as keyof typeof DotShape],
+		label: shape,
+	}
+})
 
 export default {
 	title: 'Components/SectorSelector',
@@ -87,13 +87,14 @@ const TemplatePlain: StoryFn<typeof SectorSelector> = (args) => {
 const TemplateDotStyles: StoryFn<typeof SectorSelector> = (args) => {
 	const [selectedSector, setSelectedSector] = useState(args.sector)
 	const [mapSectors, setMapSectors] = useState(args.sectors)
-	const [selectedColor, setSelectedColor] = useState('White')
-	const [selectedShape, setSelectedShape] = useState('Circle')
+	const [selectedColor, setSelectedColor] = useState(DotColor.White)
+	const [selectedShape, setSelectedShape] = useState(DotShape.Circle)
 
 	const handleColorChange = (color) => {
 		const updatedSectors = args.sectors.map((sector) => ({
 			...sector,
-			dotColor: DotColor[color as keyof typeof DotColor],
+			dotColor: color,
+			dotShape: selectedShape,
 		}))
 		setMapSectors(updatedSectors)
 		setSelectedColor(color)
@@ -101,7 +102,8 @@ const TemplateDotStyles: StoryFn<typeof SectorSelector> = (args) => {
 	const handleShapeChange = (shape) => {
 		const updatedSectors = args.sectors.map((sector) => ({
 			...sector,
-			dotShape: DotShape[shape as keyof typeof DotShape],
+			dotShape: shape,
+			dotColor: selectedColor,
 		}))
 		setMapSectors(updatedSectors)
 		setSelectedShape(shape)
@@ -111,13 +113,11 @@ const TemplateDotStyles: StoryFn<typeof SectorSelector> = (args) => {
 		<div>
 			<div style={{ display: 'flex', alignItems: 'center', gap: 30 }}>
 				<div style={{ paddingBottom: 10, display: 'table', width: 400 }}>
-					<Select value={DotColor[selectedColor as keyof typeof DotColor]} options={dotColorOptions} onChange={handleColorChange} />
+					<Select value={selectedColor} options={dotColorOptions} onChange={handleColorChange} />
 				</div>
-				<p>Selected Color: {selectedColor}</p>
 				<div style={{ paddingBottom: 10, display: 'table', width: 400 }}>
-					<Select value={DotShape[selectedShape as keyof typeof DotShape]} options={dotShapeOptions} onChange={handleShapeChange} />
+					<Select value={selectedShape} options={dotShapeOptions} onChange={handleShapeChange} />
 				</div>
-				<p>Selected Shape: {selectedShape}</p>
 			</div>
 			<SectorSelector sectors={mapSectors} d3config={args.d3config} sector={selectedSector} onChange={setSelectedSector} />
 		</div>

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -173,7 +173,6 @@ RegionSelection.args = {
 }
 
 export const DotStyles = TemplateDotStyles.bind({})
-
 DotStyles.args = {
 	sectors: pointSectors,
 	sector: '',

--- a/src/components/elements/SectorSelector/SectorSelector.stories.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.stories.tsx
@@ -1,5 +1,6 @@
 import { ALL_CROSS_SECTORS } from '@/data/analysis/cross-sectional-analysis/sectors'
 import { LARGE_SURFACE_SECTORS, STATE_SURFACE_SECTORS } from '@/data/analysis/surface/sectors'
+import { DotColor, DotShape } from '@/data/d3Map/dotStyles'
 import { StoryFn } from '@storybook/react'
 import { useState } from 'react'
 import Select from '../Select/Select'
@@ -20,6 +21,24 @@ const crossSectors = Object.entries(ALL_CROSS_SECTORS).map(([sector, sectorObj])
 	id: sector,
 	...sectorObj,
 }))
+
+const regionOptions = Object.keys(regions).map((region) => {
+	return { value: regions[region].id, label: regions[region].label }
+})
+console.log(regionOptions)
+
+const dotColorOptions = Object.keys(DotColor).map((color) => ({
+	value: DotColor[color as keyof typeof DotColor],
+	label: color,
+}))
+
+const dotShapeOptions = Object.keys(DotShape).map((shape) => ({
+	value: DotShape[shape as keyof typeof DotShape],
+	label: shape,
+}))
+
+console.log(dotColorOptions.find((color) => color.value === DotColor.White))
+console.log(dotShapeOptions)
 
 export default {
 	title: 'Components/SectorSelector',
@@ -46,10 +65,6 @@ const TemplateSelect: StoryFn<typeof SectorSelector> = (args) => {
 		setD3config(newD3config)
 	}
 
-	const regionOptions = Object.keys(regions).map((region) => {
-		return { value: regions[region].id, label: regions[region].label }
-	})
-
 	return (
 		<div>
 			<div style={{ display: 'flex', alignItems: 'center', gap: 30 }}>
@@ -67,6 +82,46 @@ const TemplatePlain: StoryFn<typeof SectorSelector> = (args) => {
 	const [selectedSector, setSelectedSector] = useState(args.sector)
 
 	return <SectorSelector {...args} sector={selectedSector} onChange={setSelectedSector} />
+}
+
+const TemplateDotStyles: StoryFn<typeof SectorSelector> = (args) => {
+	const [selectedSector, setSelectedSector] = useState(args.sector)
+	const [mapSectors, setMapSectors] = useState(args.sectors)
+	const [selectedColor, setSelectedColor] = useState('White')
+	const [selectedShape, setSelectedShape] = useState('Circle')
+
+	const handleColorChange = (color) => {
+		const updatedSectors = args.sectors.map((sector) => ({
+			...sector,
+			dotColor: DotColor[color as keyof typeof DotColor],
+		}))
+		setMapSectors(updatedSectors)
+		setSelectedColor(color)
+	}
+	const handleShapeChange = (shape) => {
+		const updatedSectors = args.sectors.map((sector) => ({
+			...sector,
+			dotShape: DotShape[shape as keyof typeof DotShape],
+		}))
+		setMapSectors(updatedSectors)
+		setSelectedShape(shape)
+	}
+
+	return (
+		<div>
+			<div style={{ display: 'flex', alignItems: 'center', gap: 30 }}>
+				<div style={{ paddingBottom: 10, display: 'table', width: 400 }}>
+					<Select value={DotColor[selectedColor as keyof typeof DotColor]} options={dotColorOptions} onChange={handleColorChange} />
+				</div>
+				<p>Selected Color: {selectedColor}</p>
+				<div style={{ paddingBottom: 10, display: 'table', width: 400 }}>
+					<Select value={DotShape[selectedShape as keyof typeof DotShape]} options={dotShapeOptions} onChange={handleShapeChange} />
+				</div>
+				<p>Selected Shape: {selectedShape}</p>
+			</div>
+			<SectorSelector sectors={mapSectors} d3config={args.d3config} sector={selectedSector} onChange={setSelectedSector} />
+		</div>
+	)
 }
 
 export const Default = TemplatePlain.bind({})
@@ -107,6 +162,19 @@ CrossSectors.args = {
 
 export const RegionSelection = TemplateSelect.bind({})
 RegionSelection.args = {
+	sectors: pointSectors,
+	sector: '',
+	d3config: {
+		width: 1000,
+		height: 600,
+		rotate: regions.CONUS.rotate,
+		scale: regions.CONUS.scale,
+	},
+}
+
+export const DotStyles = TemplateDotStyles.bind({})
+
+DotStyles.args = {
 	sectors: pointSectors,
 	sector: '',
 	d3config: {

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -137,10 +137,10 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				.selectAll('circle.point')
 				.data(pointSectors)
 				.enter()
-				.append('circle')
-				.attr('cx', (d) => projection(d.coordinates)[0])
-				.attr('cy', (d) => projection(d.coordinates)[1])
-				.attr('r', 5)
+				.append('path')
+				.attr('d', (d) => symbolGenerator.type(d.dotShape)())
+				.attr('transform', (d) => `translate(${projection(d.coordinates)})`)
+				.attr('fill', (d) => d.dotColor)
 				.attr('class', styles.point)
 		}
 
@@ -201,20 +201,18 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				})
 
 			// Draw the geobox center point
+			// projection(d3.geoCentroid(geobox))
 			geoboxGroup
 				.selectAll('circle.point')
 				.data(geoboxSectors)
 				.enter()
-				.append('circle')
-				.attr('cx', (d) => {
+				.append('path')
+				.attr('d', (d) => symbolGenerator.type(d.dotShape)())
+				.attr('transform', (d) => {
 					const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
-					return projection(d3.geoCentroid(geobox))[0]
+					return `translate(${projection(d3.geoCentroid(geobox))})`
 				})
-				.attr('cy', (d) => {
-					const geobox = d3.geoGraticule().extentMajor(d.coordinates).outline()
-					return projection(d3.geoCentroid(geobox))[1]
-				})
-				.attr('r', 5)
+				.attr('fill', (d) => d.dotColor)
 				.attr('class', styles.point)
 		}
 
@@ -275,23 +273,23 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 
 			// Draw the line start and end points
 			lineGroup
-				.selectAll('.lineEnd')
+				.selectAll('.point')
 				.data(lineSectors)
 				.enter()
 				.append('path')
 				.attr('d', (d) => symbolGenerator.type(d.dotShape)())
 				.attr('transform', (d) => `translate(${projection(d.coordinates[0])})`)
 				.attr('fill', (d) => d.dotColor)
-				.attr('class', styles.lineEnd)
+				.attr('class', styles.point)
 			lineGroup
-				.selectAll('.lineEnd')
+				.selectAll('.point')
 				.data(lineSectors)
 				.enter()
 				.append('path')
 				.attr('d', (d) => symbolGenerator.type(d.dotShape)())
 				.attr('transform', (d) => `translate(${projection(d.coordinates[1])})`)
 				.attr('fill', (d) => d.dotColor)
-				.attr('class', styles.lineEnd)
+				.attr('class', styles.point)
 		}
 	}, [sectors, onChange, sector, d3config])
 

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -1,3 +1,4 @@
+import { DotColor, DotShape } from '@/data/d3Map/dotStyles'
 import lakesJson from '@/data/d3Map/lakes.json'
 import statesJson from '@/data/d3Map/states.json'
 import mapJson from '@/data/d3Map/world.json'
@@ -17,8 +18,8 @@ export type ISectorSelectorProps = {
 		id: string
 		name: string
 		type: 'Point' | 'Geobox' | 'Line'
-		dotStyle: string
-		dotSymbol: { type: d3.SymbolType; fill: string; stroke: string } | null
+		dotShape: DotShape | null
+		dotColor: DotColor | null
 		coordinates: [number, number] | [[number, number], [number, number]]
 	}[]
 	sector: string
@@ -57,21 +58,13 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 		const statesGroup = svg.append('g')
 		statesGroup.selectAll('path.statePath').data(statesJson.features).enter().append('path').attr('d', path).attr('class', styles.statePath)
 
-		// Filter sectors that are visible in this view of the projection
-		// const filteredSectors = sectors.filter((d) => d3.geoDistance(center, d.coordinates) < Math.PI / 2)
-
-		// convert dotStyle into symbols
-		const symbolGenerator = d3.symbol().size(100) // used to create dots
-		const makeDotSymbol = (dotStyle) => {
-			const [symbolType, color] = dotStyle.split('-')
-			if (!symbolType || !color) return null
-			const symbolAttr = {
-				type: d3['symbol' + symbolType],
-				fill: color,
-				stroke: 'black',
-			}
-			return symbolAttr
-		}
+		// store symbol generator for later use
+		const symbolGenerator = d3.symbol().size(100)
+		// Set default values for dotShape and dotColor within sectors
+		sectors.forEach((sector) => {
+			sector.dotShape = sector.dotShape || DotShape.Circle
+			sector.dotColor = sector.dotColor || DotColor.White
+		})
 
 		// Split the sectors by type
 		const pointSectors = sectors.filter((d) => {
@@ -93,7 +86,6 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 			if (d.type === 'Line') {
 				const midpoint = d3.interpolate(d.coordinates[0], d.coordinates[1])(0.5)
 				isVisible = d3.geoDistance(center, midpoint) < Math.PI / 2
-				d.dotSymbol = d.dotStyle ? makeDotSymbol(d.dotStyle) : makeDotSymbol('Circle-white')
 			}
 			return d.type === 'Line' && isVisible
 		})
@@ -287,20 +279,18 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				.data(lineSectors)
 				.enter()
 				.append('path')
-				.attr('d', (d) => symbolGenerator.type(d.dotSymbol.type)())
+				.attr('d', (d) => symbolGenerator.type(d.dotShape)())
 				.attr('transform', (d) => `translate(${projection(d.coordinates[0])})`)
-				.attr('fill', (d) => d.dotSymbol.fill)
-				.attr('stroke', (d) => d.dotSymbol.stroke)
-				.attr('stroke-width', 2)
-			// .attr('class', styles.lineEnd)
+				.attr('fill', (d) => d.dotColor)
+				.attr('class', styles.lineEnd)
 			lineGroup
-				.selectAll('circle.lineEnd')
+				.selectAll('.lineEnd')
 				.data(lineSectors)
 				.enter()
-				.append('circle')
-				.attr('cx', (d) => projection(d.coordinates[1])[0])
-				.attr('cy', (d) => projection(d.coordinates[1])[1])
-				.attr('r', 5)
+				.append('path')
+				.attr('d', (d) => symbolGenerator.type(d.dotShape)())
+				.attr('transform', (d) => `translate(${projection(d.coordinates[1])})`)
+				.attr('fill', (d) => d.dotColor)
 				.attr('class', styles.lineEnd)
 		}
 	}, [sectors, onChange, sector, d3config])

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -139,7 +139,6 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				.enter()
 				.append('path')
 				.attr('d', (d) => {
-					console.log(d3[d.dotShape], d.dotShape)
 					return symbolGenerator.type(d3[d.dotShape])()
 				})
 				.attr('transform', (d) => `translate(${projection(d.coordinates)})`)
@@ -243,7 +242,6 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				.on('mouseover', (_event, d) => {
 					// name tooltip
 					const lineName = d3.select('body').append('div').attr('class', styles.lineName).text(d.name)
-					console.log(lineName)
 					svg.on('mousemove', (event) => {
 						lineName.style('left', `${event.clientX + 15}px`).style('top', `${event.clientY - 15}px`)
 					})
@@ -270,7 +268,6 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 					svg.on('mousemove', null)
 				})
 				.on('click', (_event, d) => {
-					console.log(d.id)
 					onChange(d.id)
 				})
 

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -138,7 +138,10 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 				.data(pointSectors)
 				.enter()
 				.append('path')
-				.attr('d', (d) => symbolGenerator.type(d.dotShape)())
+				.attr('d', (d) => {
+					console.log(d3[d.dotShape], d.dotShape)
+					return symbolGenerator.type(d3[d.dotShape])()
+				})
 				.attr('transform', (d) => `translate(${projection(d.coordinates)})`)
 				.attr('fill', (d) => d.dotColor)
 				.attr('class', styles.point)

--- a/src/components/elements/SectorSelector/SectorSelector.tsx
+++ b/src/components/elements/SectorSelector/SectorSelector.tsx
@@ -17,6 +17,8 @@ export type ISectorSelectorProps = {
 		id: string
 		name: string
 		type: 'Point' | 'Geobox' | 'Line'
+		dotStyle: string
+		dotSymbol: { type: d3.SymbolType; fill: string; stroke: string } | null
 		coordinates: [number, number] | [[number, number], [number, number]]
 	}[]
 	sector: string
@@ -58,6 +60,19 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 		// Filter sectors that are visible in this view of the projection
 		// const filteredSectors = sectors.filter((d) => d3.geoDistance(center, d.coordinates) < Math.PI / 2)
 
+		// convert dotStyle into symbols
+		const symbolGenerator = d3.symbol().size(100) // used to create dots
+		const makeDotSymbol = (dotStyle) => {
+			const [symbolType, color] = dotStyle.split('-')
+			if (!symbolType || !color) return null
+			const symbolAttr = {
+				type: d3['symbol' + symbolType],
+				fill: color,
+				stroke: 'black',
+			}
+			return symbolAttr
+		}
+
 		// Split the sectors by type
 		const pointSectors = sectors.filter((d) => {
 			let isVisible = false
@@ -78,6 +93,7 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 			if (d.type === 'Line') {
 				const midpoint = d3.interpolate(d.coordinates[0], d.coordinates[1])(0.5)
 				isVisible = d3.geoDistance(center, midpoint) < Math.PI / 2
+				d.dotSymbol = d.dotStyle ? makeDotSymbol(d.dotStyle) : makeDotSymbol('Circle-white')
 			}
 			return d.type === 'Line' && isVisible
 		})
@@ -267,14 +283,16 @@ const SectorSelector: React.FC<ISectorSelectorProps> = ({ sectors, sector, onCha
 
 			// Draw the line start and end points
 			lineGroup
-				.selectAll('circle.lineEnd')
+				.selectAll('.lineEnd')
 				.data(lineSectors)
 				.enter()
-				.append('circle')
-				.attr('cx', (d) => projection(d.coordinates[0])[0])
-				.attr('cy', (d) => projection(d.coordinates[0])[1])
-				.attr('r', 5)
-				.attr('class', styles.lineEnd)
+				.append('path')
+				.attr('d', (d) => symbolGenerator.type(d.dotSymbol.type)())
+				.attr('transform', (d) => `translate(${projection(d.coordinates[0])})`)
+				.attr('fill', (d) => d.dotSymbol.fill)
+				.attr('stroke', (d) => d.dotSymbol.stroke)
+				.attr('stroke-width', 2)
+			// .attr('class', styles.lineEnd)
 			lineGroup
 				.selectAll('circle.lineEnd')
 				.data(lineSectors)

--- a/src/data/analysis/cross-sectional-analysis/sectors.ts
+++ b/src/data/analysis/cross-sectional-analysis/sectors.ts
@@ -16,6 +16,8 @@ export const ALL_CROSS_SECTORS = {
 		name: 'Del Rio, TX to Bismark, ND',
 		label: ['DRT', 'BIS'],
 		type: 'Line',
+		DotShape: DotShape.Circle,
+		DotColor: DotColor.White,
 		coordinates: [
 			[-100.9, 29.37],
 			[-100.76, 46.81],
@@ -26,8 +28,6 @@ export const ALL_CROSS_SECTORS = {
 		name: 'Albuquerque, NM to Nashville, TN',
 		label: ['ABQ', 'BNA'],
 		type: 'Line',
-		dotShape: DotShape.Cross,
-		dotColor: DotColor.Blue,
 		coordinates: [
 			[-106.6, 35.1],
 			[-86.67, 36.13],
@@ -48,8 +48,6 @@ export const ALL_CROSS_SECTORS = {
 		name: 'Denver, CO to Willmington, OH',
 		label: ['DEN', 'ILN'],
 		type: 'Line',
-		dotShape: DotShape.Square,
-		dotColor: DotColor.Purple,
 		coordinates: [
 			[-104.67, 39.85],
 			[-83.79, 39.43],

--- a/src/data/analysis/cross-sectional-analysis/sectors.ts
+++ b/src/data/analysis/cross-sectional-analysis/sectors.ts
@@ -24,6 +24,7 @@ export const ALL_CROSS_SECTORS = {
 		name: 'Albuquerque, NM to Nashville, TN',
 		label: ['ABQ', 'BNA'],
 		type: 'Line',
+		dotStyle: 'Triangle-yellow',
 		coordinates: [
 			[-106.6, 35.1],
 			[-86.67, 36.13],
@@ -44,6 +45,7 @@ export const ALL_CROSS_SECTORS = {
 		name: 'Denver, CO to Willmington, OH',
 		label: ['DEN', 'ILN'],
 		type: 'Line',
+		dotStyle: 'Diamond-green',
 		coordinates: [
 			[-104.67, 39.85],
 			[-83.79, 39.43],

--- a/src/data/analysis/cross-sectional-analysis/sectors.ts
+++ b/src/data/analysis/cross-sectional-analysis/sectors.ts
@@ -1,3 +1,5 @@
+import { DotColor, DotShape } from '@/data/d3Map/dotStyles'
+
 const XSECT_SECTOR_DRT_BIS = 'drt-bis'
 const XSECT_SECTOR_ABQ_BNA = 'abq-bna'
 const XSECT_SECTOR_CRP_RIW = 'crp-riw'
@@ -24,7 +26,8 @@ export const ALL_CROSS_SECTORS = {
 		name: 'Albuquerque, NM to Nashville, TN',
 		label: ['ABQ', 'BNA'],
 		type: 'Line',
-		dotStyle: 'Triangle-yellow',
+		dotShape: DotShape.Cross,
+		dotColor: DotColor.Blue,
 		coordinates: [
 			[-106.6, 35.1],
 			[-86.67, 36.13],
@@ -45,7 +48,8 @@ export const ALL_CROSS_SECTORS = {
 		name: 'Denver, CO to Willmington, OH',
 		label: ['DEN', 'ILN'],
 		type: 'Line',
-		dotStyle: 'Diamond-green',
+		dotShape: DotShape.Square,
+		dotColor: DotColor.Purple,
 		coordinates: [
 			[-104.67, 39.85],
 			[-83.79, 39.43],

--- a/src/data/analysis/surface/sectors.ts
+++ b/src/data/analysis/surface/sectors.ts
@@ -1,3 +1,4 @@
+import { DotColor, DotShape } from '@/data/d3Map/dotStyles'
 import { ALL_SURFACE_PRODUCTS, SURFACE_PRODUCT_RAW } from './products'
 
 const SECTOR_US = 'US'
@@ -16,6 +17,8 @@ const SECTOR_CANADIAN_PRAIRIES = 'canprairies'
 const SECTOR_NORTHWEST_US = 'northwest'
 const SECTOR_SOUTHWEST_US = 'southwest'
 
+const SECTOR_CHI_METRO = 'chi'
+const SECTOR_SF_BAY = 'sfbay'
 const SECTOR_ALABAMA = 'al'
 const SECTOR_ALASKA = 'ak'
 const SECTOR_ARIZONA = 'az'
@@ -206,6 +209,22 @@ export const LARGE_SURFACE_SECTORS = {
 }
 
 export const STATE_SURFACE_SECTORS = {
+	[SECTOR_CHI_METRO]: {
+		name: 'Chicago Metro Area',
+		type: 'Point',
+		dotShape: DotShape.Triangle,
+		dotColor: DotColor.Green,
+		coordinates: [-87.66, 41.87],
+		products: [ALL_SURFACE_PRODUCTS[SURFACE_PRODUCT_RAW]],
+	},
+	[SECTOR_SF_BAY]: {
+		name: 'San Francisco Bay Area',
+		type: 'Point',
+		dotShape: DotShape.Triangle,
+		dotColor: DotColor.Green,
+		coordinates: [-122.53, 37.77],
+		products: [ALL_SURFACE_PRODUCTS[SURFACE_PRODUCT_RAW]],
+	},
 	[SECTOR_ALASKA]: {
 		name: 'Alaska',
 		type: 'Point',
@@ -425,7 +444,7 @@ export const STATE_SURFACE_SECTORS = {
 	[SECTOR_OREGON]: {
 		name: 'Oregon',
 		type: 'Point',
-		coordinates: [-122.67, 45.52],
+		coordinates: [-120.73, 43.77],
 		products: [ALL_SURFACE_PRODUCTS[SURFACE_PRODUCT_RAW]],
 	},
 	[SECTOR_PENNSYLVANIA]: {
@@ -485,7 +504,7 @@ export const STATE_SURFACE_SECTORS = {
 	[SECTOR_WASHINGTON]: {
 		name: 'Washington',
 		type: 'Point',
-		coordinates: [-122.33, 47.61],
+		coordinates: [-120.47, 47.31],
 		products: [ALL_SURFACE_PRODUCTS[SURFACE_PRODUCT_RAW]],
 	},
 	[SECTOR_WISCONSIN]: {

--- a/src/data/d3Map/dotStyles.ts
+++ b/src/data/d3Map/dotStyles.ts
@@ -1,0 +1,19 @@
+import * as d3 from 'd3'
+export enum DotShape {
+	Circle = d3.symbolCircle,
+	Cross = d3.symbolCross,
+	Diamond = d3.symbolDiamond,
+	Square = d3.symbolSquare,
+	Triangle = d3.symbolTriangle,
+	Wye = d3.symbolWye,
+}
+export enum DotColor {
+	Blue = '#007bff',
+	Green = '#28a745',
+	Red = '#dc3545',
+	Yellow = '#ffc107',
+	Purple = '#6f42c1',
+	Orange = '#ff851b',
+	Gray = '#343a40',
+	White = '#ffffff',
+}

--- a/src/data/d3Map/dotStyles.ts
+++ b/src/data/d3Map/dotStyles.ts
@@ -1,12 +1,13 @@
-import * as d3 from 'd3'
 export enum DotShape {
-	Circle = d3.symbolCircle,
-	Cross = d3.symbolCross,
-	Diamond = d3.symbolDiamond,
-	Square = d3.symbolSquare,
-	Triangle = d3.symbolTriangle,
-	Wye = d3.symbolWye,
+	Circle = 'symbolCircle',
+	Cross = 'symbolCross',
+	Diamond = 'symbolDiamond',
+	Square = 'symbolSquare',
+	Star = 'symbolStar',
+	Triangle = 'symbolTriangle',
+	Wye = 'symbolWye',
 }
+
 export enum DotColor {
 	Blue = '#007bff',
 	Green = '#28a745',


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 8173647468

## Description
Entire sector select component refactored to use symbols as markers for point, center of geobox or end of line sector. Default is established in component as White Circle. Input controls added to component to manipulate this feature; dotColor and dotShape. These are stored in Enum lists in /src/data/d3Map/dotStyles.ts. Slight adjustments to data files for analysis to correct some bad placement of a few point sectors and add additional working examples that use a "custom" dot style.

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run storybook` and `npm run build`

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):
![custom-dots](https://github.com/user-attachments/assets/458d3f63-c9b6-4cbc-b03a-7b768349f5bb)


## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
