### PR TITLE
Analysis Sidebar active links

### DIFF
--- a/src/components/layout/SidebarPanels/IsentropicPanel/IsentropicPanel.tsx
+++ b/src/components/layout/SidebarPanels/IsentropicPanel/IsentropicPanel.tsx
@@ -5,6 +5,7 @@ import { SidebarLink } from '@/components/elements/SidebarLink/SidebarLink'
 import { SidebarSectionHeader } from '@/components/elements/SidebarSectionHeader/SidebarSectionHeader'
 import SidebarPanelPad from '@/components/layout/SidebarPanelPad/SidebarPanelPad'
 import { ALL_ISENTROPIC_PRODUCTS } from '@/data/analysis/isentropic/products'
+import { useParams } from 'next/navigation'
 import styles from './IsentropicPanel.module.scss'
 
 interface IsentropicPanelProps {
@@ -12,6 +13,7 @@ interface IsentropicPanelProps {
 }
 
 export const IsentropicPanel = ({ basepath }: IsentropicPanelProps) => {
+	const { isentropicProductId: productId } = useParams()
 	const productsArray = Object.keys(ALL_ISENTROPIC_PRODUCTS).map((productId) => {
 		return { id: productId, label: ALL_ISENTROPIC_PRODUCTS[productId].label }
 	})
@@ -23,7 +25,7 @@ export const IsentropicPanel = ({ basepath }: IsentropicPanelProps) => {
 				<SidebarGroup title="Select a Product">
 					<SidebarPanelPad>
 						{productsArray.map(({ id, label }) => (
-							<SidebarLink key={id} name={label} linkUrl={`/weather-data/analysis/isentropic-maps/${id}`} />
+							<SidebarLink key={id} name={label} active={id === productId} linkUrl={`/weather-data/analysis/isentropic-maps/${id}`} />
 						))}
 					</SidebarPanelPad>
 				</SidebarGroup>

--- a/src/components/layout/SidebarPanels/RAPMesoPanel/RAPMesoPanel.tsx
+++ b/src/components/layout/SidebarPanels/RAPMesoPanel/RAPMesoPanel.tsx
@@ -5,6 +5,7 @@ import { SidebarLink } from '@/components/elements/SidebarLink/SidebarLink'
 import { SidebarSectionHeader } from '@/components/elements/SidebarSectionHeader/SidebarSectionHeader'
 import SidebarPanelPad from '@/components/layout/SidebarPanelPad/SidebarPanelPad'
 import { ALL_RAPMESO_PRODUCTS } from '@/data/analysis/rap-mesoanalysis/products'
+import { useParams } from 'next/navigation'
 import styles from './RAPMesoPanel.module.scss'
 
 interface RAPMesoPanelProps {
@@ -12,6 +13,7 @@ interface RAPMesoPanelProps {
 }
 
 export const RAPMesoPanel = ({ basepath }: RAPMesoPanelProps) => {
+	const { rapmesoProductId: productId } = useParams()
 	const productsArray = Object.keys(ALL_RAPMESO_PRODUCTS).map((productId) => {
 		return { id: productId, label: ALL_RAPMESO_PRODUCTS[productId].label }
 	})
@@ -23,7 +25,7 @@ export const RAPMesoPanel = ({ basepath }: RAPMesoPanelProps) => {
 				<SidebarGroup title="Select a Product">
 					<SidebarPanelPad>
 						{productsArray.map(({ id, label }) => (
-							<SidebarLink key={id} name={label} linkUrl={`/weather-data/analysis/RAP-mesoanalysis/${id}`} />
+							<SidebarLink key={id} name={label} active={id === productId} linkUrl={`/weather-data/analysis/RAP-mesoanalysis/${id}`} />
 						))}
 					</SidebarPanelPad>
 				</SidebarGroup>

--- a/src/components/layout/SidebarPanels/SoundingsPanel/SoundingsPanel.tsx
+++ b/src/components/layout/SidebarPanels/SoundingsPanel/SoundingsPanel.tsx
@@ -110,7 +110,12 @@ export const SoundingsPanel = ({ basepath, isActive }: soundingsPanelProps) => {
 					<Button onClick={openSectorSelectorPanel} label={getSelectorLabel(siteId)} />
 				</div>
 				{productsArray.map(({ id, label }) => (
-					<SidebarLink key={id} name={label} linkUrl={`/weather-data/analysis/soundings/${id}/${regionId}/${siteId}`} />
+					<SidebarLink
+						key={id}
+						name={label}
+						active={id === productId}
+						linkUrl={`/weather-data/analysis/soundings/${id}/${regionId}/${siteId}`}
+					/>
 				))}
 			</SidebarPanelPad>
 		</div>

--- a/src/components/layout/SidebarPanels/SurfaceMapsPanel/SurfaceMapsPanel.tsx
+++ b/src/components/layout/SidebarPanels/SurfaceMapsPanel/SurfaceMapsPanel.tsx
@@ -110,7 +110,12 @@ export const SurfaceMapsPanel = ({ basepath, isActive }: SurfaceMapsPanelProps) 
 					<Button onClick={openSectorSelectorPanel} label={getSelectorLabel(siteId)} />
 				</div>
 				{productsArray.map(({ id, label }) => (
-					<SidebarLink key={id} name={label} linkUrl={`/weather-data/analysis/surface-maps/${id}/${regionId}/${siteId}`} />
+					<SidebarLink
+						key={id}
+						name={label}
+						active={id === productId}
+						linkUrl={`/weather-data/analysis/surface-maps/${id}/${regionId}/${siteId}`}
+					/>
 				))}
 			</SidebarPanelPad>
 		</div>

--- a/src/components/layout/SidebarPanels/UpperAirPanel/UpperAirPanel.tsx
+++ b/src/components/layout/SidebarPanels/UpperAirPanel/UpperAirPanel.tsx
@@ -62,11 +62,11 @@ export const UpperAirPanel = ({ basepath, isActive }: UpperAirPanelProps) => {
 			return Object.keys(ALL_UPPERAIR_SECTORS[siteId as string].levels).map((levelId) => {
 				const thisLevel = ALL_UPPERAIR_SECTORS[siteId as string].levels[levelId]
 				return {
-					levelId: levelId,
+					levelIdArr: levelId,
 					label: thisLevel.label,
 					columns: thisLevel.columns,
 					products: thisLevel.products.map((productId) => ({
-						productId: productId,
+						productIdArr: productId,
 						label: ALL_UPPERAIR_PRODUCTS[productId].label,
 					})),
 				}
@@ -81,14 +81,15 @@ export const UpperAirPanel = ({ basepath, isActive }: UpperAirPanelProps) => {
 				<div className={styles.options}>
 					<Select value={siteId} options={sectorOptions} onChange={handleSectorChange} />
 				</div>
-				{productsArray.map(({ levelId, label, columns, products }) => (
-					<SidebarGroup key={levelId} title={label}>
+				{productsArray.map(({ levelIdArr, label, columns, products }) => (
+					<SidebarGroup key={levelIdArr} title={label}>
 						<SidebarGrid columns={columns}>
-							{products.map(({ productId, label }) => (
+							{products.map(({ productIdArr, label }) => (
 								<SidebarLink
-									key={productId}
+									key={productIdArr}
 									name={label}
-									linkUrl={`/weather-data/analysis/upper-air/${levelId}/${productId}/${regionId}/${siteId}`}
+									active={productIdArr === productId && levelIdArr === levelId}
+									linkUrl={`/weather-data/analysis/upper-air/${levelIdArr}/${productIdArr}/${regionId}/${siteId}`}
 								/>
 							))}
 						</SidebarGrid>


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 9256130204

## Description
Analysis sidebars were all deployed without utilizing `active` property to highlight current selected product in sidebar. I have updated all panels.

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run dev` and `npm run build`

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):
![image](https://github.com/user-attachments/assets/3c9d6de5-fe22-44d5-91d6-ceb29dde7bc1)
![image](https://github.com/user-attachments/assets/66d4dcaa-e02b-471c-9c05-7dc8f3123851)

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
