### PR TITLE
update objects to include all data

### DIFF
--- a/src/components/layout/SidebarPanels/NexradSidebarPanel/NexradSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/NexradSidebarPanel/NexradSidebarPanel.tsx
@@ -49,9 +49,7 @@ const NexradSidebarPanel = () => {
 		setSectorSelectorD3config(newD3config)
 		const selectedSectors = region.sites.map((siteId) => ({
 			id: siteId,
-			name: NEXRAD_SITES[siteId].name,
-			type: NEXRAD_SITES[siteId].type,
-			coordinates: NEXRAD_SITES[siteId].coordinates,
+			...NEXRAD_SITES[siteId],
 		}))
 		setSectorSelectorSectors(selectedSectors)
 	}, [regionId, setSectorSelectorD3config, setSectorSelectorSectors])

--- a/src/components/layout/SidebarPanels/SatRadSidebarPanel/SatradSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/SatRadSidebarPanel/SatradSidebarPanel.tsx
@@ -58,9 +58,7 @@ const SatradSidebarPanel = () => {
 			setSectorSelectorD3config(newD3config)
 			const selectedSectors = SATRAD_SCALE_REGIONS[tempRegionIdRef.current as string].sectors.map((sectorId) => ({
 				id: sectorId,
-				name: ALL_SATRAD_SECTORS[sectorId].name,
-				type: ALL_SATRAD_SECTORS[sectorId].type,
-				coordinates: ALL_SATRAD_SECTORS[sectorId].coordinates,
+				...ALL_SATRAD_SECTORS[sectorId],
 			}))
 			setSectorSelectorSectors(selectedSectors)
 		} else {

--- a/src/components/layout/SidebarPanels/SoundingsPanel/SoundingsPanel.tsx
+++ b/src/components/layout/SidebarPanels/SoundingsPanel/SoundingsPanel.tsx
@@ -65,9 +65,7 @@ export const SoundingsPanel = ({ basepath, isActive }: soundingsPanelProps) => {
 			setSectorSelectorD3config(newD3config)
 			const selectedSectors = region.sites.map((siteId) => ({
 				id: siteId,
-				name: ALL_SOUNDING_SITES[siteId].name,
-				type: ALL_SOUNDING_SITES[siteId].type,
-				coordinates: ALL_SOUNDING_SITES[siteId].coordinates,
+				...ALL_SOUNDING_SITES[siteId],
 			}))
 			setSectorSelectorSectors(selectedSectors)
 		}

--- a/src/components/layout/SidebarPanels/SurfaceMapsPanel/SurfaceMapsPanel.tsx
+++ b/src/components/layout/SidebarPanels/SurfaceMapsPanel/SurfaceMapsPanel.tsx
@@ -64,9 +64,7 @@ export const SurfaceMapsPanel = ({ basepath, isActive }: SurfaceMapsPanelProps) 
 				}
 				const selectedSectors = region.sites.map((siteId) => ({
 					id: siteId,
-					name: ALL_SURFACE_SECTORS[siteId].name,
-					type: ALL_SURFACE_SECTORS[siteId].type,
-					coordinates: ALL_SURFACE_SECTORS[siteId].coordinates,
+					...ALL_SURFACE_SECTORS[siteId],
 				}))
 				setSectorSelectorD3config(newD3config)
 				setSectorSelectorSectors(selectedSectors)


### PR DESCRIPTION
## Monday.com Item

Monday Item ID: 9256254421

## Description

Sector Selector maps were not showing the right icons.  This was happening because when the data was pulled in previously it was not using the dotShape or dotColor.  I have updated the code to include all values so it now works properly.

## How Has This Been Tested?

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
