### PR TITLE
Fix repeated API calls when changing number of frames setting

### DIFF
--- a/src/components/blocks/_animatorSettingPanels/NexradAnimatorSettings/NexradAnimatorSettings.tsx
+++ b/src/components/blocks/_animatorSettingPanels/NexradAnimatorSettings/NexradAnimatorSettings.tsx
@@ -17,7 +17,7 @@ const NexradAnimatorSettings = () => {
 			<p>Number Of Frames (1-200)</p>
 			<div className={styles.group}>
 				<b>{nexradNumberOfFrames}</b>
-				<RangeInput minValue={1} maxValue={200} value={nexradNumberOfFrames} onChange={(value) => setNexradNumberOfFrames(value)} />
+				<RangeInput minValue={1} maxValue={200} value={nexradNumberOfFrames} onChangeEnd={(value) => setNexradNumberOfFrames(value)} />
 			</div>
 			<p>Animation Speed (slow/fast)</p>
 			<div className={styles.group}>

--- a/src/components/blocks/_animatorSettingPanels/SatradAnimatorSettings/SatradAnimatorSettings.tsx
+++ b/src/components/blocks/_animatorSettingPanels/SatradAnimatorSettings/SatradAnimatorSettings.tsx
@@ -17,7 +17,7 @@ const SatradAnimatorSettings = () => {
 			<p>Number Of Frames (1-200)</p>
 			<div className={styles.group}>
 				<b>{satradNumberOfFrames}</b>
-				<RangeInput minValue={1} maxValue={200} value={satradNumberOfFrames} onChange={(value) => setSatradNumberOfFrames(value)} />
+				<RangeInput minValue={1} maxValue={200} value={satradNumberOfFrames} onChangeEnd={(value) => setSatradNumberOfFrames(value)} />
 			</div>
 			<p>Animation Speed (slow/fast)</p>
 			<div className={styles.group}>

--- a/src/components/elements/RangeInput/RangeInput.tsx
+++ b/src/components/elements/RangeInput/RangeInput.tsx
@@ -1,22 +1,42 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styles from './RangeInput.module.scss'
 
 interface IRangeInputProps {
 	minValue: number
 	maxValue: number
 	value: number
-	onChange: (value: number) => void
+	onChange?: (value: number) => void
 	unitStep?: number
+	onChangeEnd?: (value: number) => void
 }
 
-const RangeInput: React.FC<IRangeInputProps> = ({ minValue, maxValue, value, onChange, unitStep = 1 }) => {
+const RangeInput: React.FC<IRangeInputProps> = ({ minValue, maxValue, value, onChange, unitStep = 1, onChangeEnd }) => {
+	const [localValue, setLocalValue] = useState(value)
 	const handleSliderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-		onChange(Number(event.target.value))
+		const newValue = Number(event.target.value)
+		if (onChange) {
+			onChange(newValue)
+		} else {
+			setLocalValue(newValue)
+		}
+	}
+	const handleSliderChangeEnd = (event: any) => {
+		onChangeEnd && onChangeEnd(Number(event.target.value))
 	}
 
 	return (
 		<div className={styles.rangeInput}>
-			<input type="range" min={minValue} max={maxValue} step={unitStep} value={value} onChange={handleSliderChange} className={styles.slider} />
+			<input
+				type="range"
+				min={minValue}
+				max={maxValue}
+				step={unitStep}
+				value={onChange ? value : localValue}
+				onChange={handleSliderChange}
+				onMouseUp={handleSliderChangeEnd}
+				onTouchEnd={handleSliderChangeEnd}
+				className={styles.slider}
+			/>
 		</div>
 	)
 }


### PR DESCRIPTION
## Monday.com Item

Monday Item ID: 9256146563

## Description

Added onChangeEnd functionality to the number slider so that it doesn't spam the api with requests.

## How Has This Been Tested?

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
