### PR TITLE
Make FPS animator setting more linear

### DIFF
--- a/src/components/blocks/_animatorSettingPanels/NexradAnimatorSettings/NexradAnimatorSettings.tsx
+++ b/src/components/blocks/_animatorSettingPanels/NexradAnimatorSettings/NexradAnimatorSettings.tsx
@@ -9,9 +9,6 @@ const NexradAnimatorSettings = () => {
 	const setNexradFrameRate = useRootStore.use.setNexradFrameRate()
 	const setNexradNumberOfFrames = useRootStore.use.setNexradNumberOfFrames()
 
-	const frameDurationMs = 16 + (1000 - 16) * nexradFrameRate
-	const fps = 1000 / frameDurationMs
-
 	return (
 		<div className={styles.NexradAnimatorSettings}>
 			<p>Number Of Frames (1-200)</p>
@@ -21,14 +18,8 @@ const NexradAnimatorSettings = () => {
 			</div>
 			<p>Animation Speed (slow/fast)</p>
 			<div className={styles.group}>
-				<b>{fps >= 1 ? Math.floor(fps) : fps.toFixed(1)} fps</b>
-				<RangeInput
-					minValue={0.01}
-					maxValue={0.99}
-					value={1 - nexradFrameRate}
-					unitStep={0.01}
-					onChange={(value) => setNexradFrameRate(1 - value)}
-				/>
+				<b>{nexradFrameRate} fps</b>
+				<RangeInput minValue={1} maxValue={40} value={nexradFrameRate} unitStep={1} onChange={setNexradFrameRate} />
 			</div>
 		</div>
 	)

--- a/src/components/blocks/_animatorSettingPanels/SatradAnimatorSettings/SatradAnimatorSettings.tsx
+++ b/src/components/blocks/_animatorSettingPanels/SatradAnimatorSettings/SatradAnimatorSettings.tsx
@@ -9,9 +9,6 @@ const SatradAnimatorSettings = () => {
 	const setSatradFrameRate = useRootStore.use.setSatradFrameRate()
 	const setSatradNumberOfFrames = useRootStore.use.setSatradNumberOfFrames()
 
-	const frameDurationMs = 16 + (1000 - 16) * satradFrameRate
-	const fps = 1000 / frameDurationMs
-
 	return (
 		<div className={styles.SatradAnimatorSettings}>
 			<p>Number Of Frames (1-200)</p>
@@ -21,14 +18,8 @@ const SatradAnimatorSettings = () => {
 			</div>
 			<p>Animation Speed (slow/fast)</p>
 			<div className={styles.group}>
-				<b>{fps >= 1 ? Math.floor(fps) : fps.toFixed(1)} fps</b>
-				<RangeInput
-					minValue={0.01}
-					maxValue={0.99}
-					value={1 - satradFrameRate}
-					unitStep={0.01}
-					onChange={(value) => setSatradFrameRate(1 - value)}
-				/>
+				<b>{satradFrameRate} fps</b>
+				<RangeInput minValue={1} maxValue={40} value={satradFrameRate} unitStep={1} onChange={setSatradFrameRate} />
 			</div>
 		</div>
 	)

--- a/src/components/blocks/_animators/NexradAnimator/NexradAnimator.tsx
+++ b/src/components/blocks/_animators/NexradAnimator/NexradAnimator.tsx
@@ -43,7 +43,7 @@ const NexradAnimator: React.FC<NexradAnimatorProps> = ({ productInfo }) => {
 					<Animator
 						frames={nexradData}
 						ratio={ratio}
-						interval={nexradFrameRate}
+						interval={1000 / nexradFrameRate}
 						settingsComponent={
 							<AnimatorSettings title="Settings">
 								<NexradAnimatorSettings />

--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -32,7 +32,7 @@ export const Animator = ({
 	ratio = 1,
 	height,
 	width,
-	interval = 0.1,
+	interval = 200,
 	hideControls = false,
 	autoPlay = false,
 	hideZoomControls = false,
@@ -73,7 +73,7 @@ export const Animator = ({
 					}
 					return nextFrame
 				})
-			}, interval * 1000)
+			}, interval)
 		} else if (intervalRef.current) {
 			clearInterval(intervalRef.current)
 			intervalRef.current = null

--- a/src/store/nexradSlice.ts
+++ b/src/store/nexradSlice.ts
@@ -10,6 +10,6 @@ export interface INexradSlice {
 export const createNexradSlice: ZustandStateSlice<INexradSlice> = (set) => ({
 	nexradNumberOfFrames: 24,
 	setNexradNumberOfFrames: (frames: number) => set(() => ({ nexradNumberOfFrames: frames })),
-	nexradFrameRate: 0.25,
+	nexradFrameRate: 15,
 	setNexradFrameRate: (frameRate: number) => set(() => ({ nexradFrameRate: frameRate })),
 })

--- a/src/store/satradSlice.ts
+++ b/src/store/satradSlice.ts
@@ -14,6 +14,6 @@ export const createSatradSlice: ZustandStateSlice<ISatradSlice> = (set) => ({
 	setSatradNumberOfFrames: (frames: number) => set(() => ({ satradNumberOfFrames: frames })),
 	satradFrameStep: 1,
 	setSatradFrameStep: (frameStep: number) => set(() => ({ satradFrameStep: frameStep })),
-	satradFrameRate: 0.1,
+	satradFrameRate: 15,
 	setSatradFrameRate: (frameRate: number) => set(() => ({ satradFrameRate: frameRate })),
 })


### PR DESCRIPTION
## Monday.com Item

Monday Item ID: 9256142770

## Description

I changed the math behind the setting to make it a straight FPS chooser.

## How Has This Been Tested?

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
