### PR TITLE
Fixed responsive issues and refresh issues.

### DIFF
--- a/src/components/elements/Animator/Animator.module.scss
+++ b/src/components/elements/Animator/Animator.module.scss
@@ -25,6 +25,7 @@
     width: 95%;
     gap: 10px;
     flex-wrap: wrap;
+    justify-content: space-between;
     & > div:first-child {
       width: 100%;
       min-width: 100%;

--- a/src/components/elements/AnimatorSettings/AnimatorSettings.tsx
+++ b/src/components/elements/AnimatorSettings/AnimatorSettings.tsx
@@ -26,7 +26,7 @@ const AnimatorSettings = ({ title, children }) => {
 			<FloatingInfoPanel
 				className={styles.AnimatorSettingsPanel}
 				title={title}
-				style={{ visibility: open ? 'visible' : 'hidden' }}
+				style={{ visibility: open ? 'visible' : 'hidden', opacity: open ? 1 : 0 }}
 				onClose={() => {
 					setOpen(false)
 				}}

--- a/src/components/elements/AnimatorSettings/AnimatorSettings.tsx
+++ b/src/components/elements/AnimatorSettings/AnimatorSettings.tsx
@@ -23,17 +23,16 @@ const AnimatorSettings = ({ title, children }) => {
 					style={{ pointerEvents: open ? 'none' : 'auto' }} // fix issue with "click outside to close" floating panel
 				/>
 			</div>
-			{open && (
-				<FloatingInfoPanel
-					className={styles.AnimatorSettingsPanel}
-					title={title}
-					onClose={() => {
-						setOpen(false)
-					}}
-				>
-					{children}
-				</FloatingInfoPanel>
-			)}
+			<FloatingInfoPanel
+				className={styles.AnimatorSettingsPanel}
+				title={title}
+				style={{ visibility: open ? 'visible' : 'hidden' }}
+				onClose={() => {
+					setOpen(false)
+				}}
+			>
+				{children}
+			</FloatingInfoPanel>
 		</div>
 	)
 }

--- a/src/components/elements/FloatingInfoPanel/FloatingInfoPanel.tsx
+++ b/src/components/elements/FloatingInfoPanel/FloatingInfoPanel.tsx
@@ -8,9 +8,10 @@ interface FloatingInfoPanelProps {
 	onClose: () => void
 	children: React.ReactNode
 	className?: string
+	style?: React.CSSProperties
 }
 
-export const FloatingInfoPanel: React.FC<FloatingInfoPanelProps> = ({ title, onClose, children, className }) => {
+export const FloatingInfoPanel: React.FC<FloatingInfoPanelProps> = ({ title, onClose, children, className, style }) => {
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
 			if ((event.target as HTMLElement).closest(`.${styles.floatingInfoPanel}`) === null) {
@@ -25,7 +26,7 @@ export const FloatingInfoPanel: React.FC<FloatingInfoPanelProps> = ({ title, onC
 	}, [onClose])
 
 	return (
-		<div className={`${className || ''} ${styles.floatingInfoPanel}`}>
+		<div className={`${className || ''} ${styles.floatingInfoPanel}`} style={style}>
 			<div className={styles.header}>
 				<h2>{title}</h2>
 				<button className={styles.closeButton} onClick={onClose}>


### PR DESCRIPTION
## Monday.com Item

Monday Item ID: 9332863274

## Description

I made the settings panel always exist but just hidden from view via css so the js involved in counting down the refresh data still works properly.  I also fixed the responsive location of the settings panel on mobile to make sure it doesn't get cut off on smaller phone screens.

## How Has This Been Tested?

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
