### PR TITLE
Basic Forecast Animator

### DIFF
--- a/src/app/weather-data/forecast-models/[forecastModelId]/[forecastSectorId]/[forecastLevelId]/[forecastProductId]/page.tsx
+++ b/src/app/weather-data/forecast-models/[forecastModelId]/[forecastSectorId]/[forecastLevelId]/[forecastProductId]/page.tsx
@@ -1,5 +1,19 @@
-const Page = () => {
-	return <>Model content</>
-}
+import { getDataPageContent } from '@/apollo/strapi/getDataPageContent'
+import ForecastAnimator from '@/components/blocks/_animators/ForecastAnimator/ForecastAnimator'
+import { getForecastPageIdByParams } from '@/util/weatherDataPageLookup'
 
+const Page = async ({ params }) => {
+	const { forecastModelId: modelId, forecastLevelId: levelId, forecastProductId: productId } = params
+	const pageId = getForecastPageIdByParams(modelId, levelId, productId)
+	const pageData = await getDataPageContent(pageId)
+	return (
+		<ForecastAnimator
+			productInfo={{
+				info: pageData.productInfo || pageData.SEO.metaTitle,
+				image: pageData.ProductImage?.url || pageData.SEO.metaImage?.url,
+				description: pageData.productDescription || pageData.SEO.metaDescription,
+			}}
+		/>
+	)
+}
 export default Page

--- a/src/components/blocks/_animatorSettingPanels/ForecastAnimatorSettings/ForecastAnimatorSettings.tsx
+++ b/src/components/blocks/_animatorSettingPanels/ForecastAnimatorSettings/ForecastAnimatorSettings.tsx
@@ -1,0 +1,69 @@
+'use client'
+import Checkbox from '@/components/elements/Checkbox/Checkbox'
+import MultiButtonToggle from '@/components/elements/MultiButtonToggle/MultiButtonToggle'
+import RangeInput from '@/components/elements/RangeInput/RangeInput'
+import { useIntervalWithCountdown } from '@/hooks/useIntervalWithCountdown'
+import { useRootStore } from '@/store/useRootStore'
+import { formatTimeMstoMinutesAndSeconds } from '@/util/time'
+import styles from '../AnimatorSettings.module.scss'
+
+const ForecastAnimatorSettings = ({ refreshData }) => {
+	const forecastFrameRate = useRootStore.use.forecastFrameRate()
+	const setForecastFrameRate = useRootStore.use.setForecastFrameRate()
+	const forecastLastFrameDwellTime = useRootStore.use.forecastLastFrameDwellTime()
+	const setForecastLastFrameDwellTime = useRootStore.use.setForecastLastFrameDwellTime()
+	const forecastLastFrameDwell = useRootStore.use.forecastLastFrameDwell()
+	const setForecastLastFrameDwell = useRootStore.use.setForecastLastFrameDwell()
+	const forecastDataRefreshActive = useRootStore.use.forecastDataRefreshActive()
+	const forecastDataRefreshInterval = useRootStore.use.forecastDataRefreshInterval()
+	const setForecastDataRefreshInterval = useRootStore.use.setForecastDataRefreshInterval()
+	const setForecastDataRefreshActive = useRootStore.use.setForecastDataRefreshActive()
+
+	const refreshAlertData = async () => {
+		if (forecastDataRefreshActive && refreshData) {
+			refreshData()
+		}
+	}
+	const { timeRemaining } = useIntervalWithCountdown(refreshAlertData, forecastDataRefreshInterval * 60 * 1000)
+
+	return (
+		<div className={styles.animatorSettings}>
+			<p>Animation Speed (slow/fast)</p>
+			<div className={styles.group}>
+				<b>{forecastFrameRate} fps</b>
+				<RangeInput minValue={1} maxValue={40} value={forecastFrameRate} unitStep={1} onChange={setForecastFrameRate} />
+			</div>
+			<p>Last frame Dwell Time (slow/fast)</p>
+			<div className={styles.padding}>
+				<Checkbox label={'Last Frame Dwell Enabled'} value={forecastLastFrameDwell} onChange={setForecastLastFrameDwell} />
+			</div>
+			<div className={styles.group}>
+				<b>{forecastLastFrameDwellTime} sec</b>
+				<RangeInput minValue={0.1} maxValue={5} value={forecastLastFrameDwellTime} unitStep={0.1} onChange={setForecastLastFrameDwellTime} />
+			</div>
+			<p>Refresh Settings</p>
+			<div className={styles.padding}>
+				<Checkbox
+					label={`Enable auto-refresh ${forecastDataRefreshActive ? `(${formatTimeMstoMinutesAndSeconds(timeRemaining)})` : ''}`}
+					value={forecastDataRefreshActive}
+					onChange={setForecastDataRefreshActive}
+				/>
+			</div>
+			<div className={styles.group}>
+				<MultiButtonToggle
+					options={[
+						{ label: '1 min', value: 1 },
+						{ label: '2 min', value: 2 },
+						{ label: '5 min', value: 5 },
+						{ label: '10 min', value: 10 },
+					]}
+					value={forecastDataRefreshInterval}
+					onChange={setForecastDataRefreshInterval}
+					inactive={!forecastDataRefreshActive}
+				/>
+			</div>
+		</div>
+	)
+}
+
+export default ForecastAnimatorSettings

--- a/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.module.scss
+++ b/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.module.scss
@@ -1,0 +1,19 @@
+.forecastAnimatorContainer {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
+	max-width: 100%;
+	max-height: 100%;
+	overflow: hidden;
+}
+
+.forecastAnimator {
+	flex-grow: 1;
+	max-height: 100%;
+	display: flex;
+	justify-content: center;
+	position: relative;
+	overflow: auto;
+	width: 100%;
+}

--- a/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { Animator } from '@/components/elements/Animator/Animator'
+import AnimatorSettings from '@/components/elements/AnimatorSettings/AnimatorSettings'
+import { Tab, Tabs } from '@/components/elements/Tabs/Tabs'
+import MobileIconNav from '@/components/layout/MobileIconNav/MobileIconNav'
+import { useIsMobile } from '@/hooks/useIsMobile'
+import { useRootStore } from '@/store/useRootStore'
+import { getForecastData } from '@/util/dataCalls/forecast/query-forecast'
+import { faDownload, faInfoCircle, faWarning } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useParams } from 'next/navigation'
+import React, { useCallback, useEffect, useState } from 'react'
+import ProductInfo, { ProductInfoProps } from '../../ProductInfo/ProductInfo'
+import ForecastAnimatorSettings from '../../_animatorSettingPanels/ForecastAnimatorSettings/ForecastAnimatorSettings'
+import styles from './ForecastAnimator.module.scss'
+
+interface ForecastAnimatorProps {
+	productInfo: ProductInfoProps
+}
+
+const ForecastAnimator: React.FC<ForecastAnimatorProps> = ({ productInfo }) => {
+	const { isMobile } = useIsMobile()
+	const { forecastModelId: modelId, forecastSectorId: sectorId, forecastLevelId: levelId, forecastProductId: productId } = useParams()
+	const runId = 'current' // Placeholder for runtimeId, will need to come from params
+	const [activeTab, setActiveTab] = useState(-1)
+	const forecastFrameRate = useRootStore.use.forecastFrameRate()
+	const forecastZoomState = useRootStore.use.forecastZoomState()
+	const setForecastZoomState = useRootStore.use.setForecastZoomState()
+	const forecastZoomFill = useRootStore.use.forecastZoomFill()
+	const setForecastZoomFill = useRootStore.use.setForecastZoomFill()
+	const forecastMapFullScreen = useRootStore.use.forecastMapFullScreen()
+	const setForecastMapFullScreen = useRootStore.use.setForecastMapFullScreen()
+	const forecastLastFrameDwell = useRootStore.use.forecastLastFrameDwell()
+	const forecastLastFrameDwellTime = useRootStore.use.forecastLastFrameDwellTime()
+	const [ratio, setRatio] = useState(1)
+	const [forecastData, setForecastData] = useState([])
+
+	const getData = useCallback(async () => {
+		console.log('ForecastAnimator: Fetching data', modelId, runId, sectorId, levelId, productId)
+		const data = await getForecastData(modelId, runId, sectorId, levelId, productId)
+		setRatio(data.imageInfo.width / data.imageInfo.height)
+		setForecastData(data.frames)
+		console.log('ForecastAnimator: data fetched')
+	}, [modelId, runId, sectorId, levelId, productId, setRatio, setForecastData])
+
+	useEffect(() => {
+		getData()
+	}, [modelId, runId, sectorId, levelId, productId, getData])
+
+	useEffect(() => {
+		setForecastZoomFill(isMobile)
+	}, [isMobile, setForecastZoomFill])
+
+	return (
+		<>
+			<div className={styles.forecastAnimatorContainer}>
+				<div className={styles.forecastAnimator}>
+					<Animator
+						frames={forecastData}
+						startFrame={0}
+						ratio={ratio}
+						initialZoomState={forecastZoomState}
+						setZoomState={setForecastZoomState}
+						zoomFill={forecastZoomFill}
+						setZoomFill={setForecastZoomFill}
+						fullScreen={forecastMapFullScreen}
+						setFullScreen={setForecastMapFullScreen}
+						interval={1000 / forecastFrameRate}
+						lastFrameDwell={forecastLastFrameDwell}
+						lastFrameDwellTime={forecastLastFrameDwellTime * 1000}
+						settingsComponent={
+							<AnimatorSettings title="Settings">
+								<ForecastAnimatorSettings refreshData={getData} />
+							</AnimatorSettings>
+						}
+					/>
+				</div>
+				<Tabs activeTab={activeTab} setActiveTab={setActiveTab}>
+					<Tab label="Product Info" icon={<FontAwesomeIcon icon={faInfoCircle} />}>
+						<ProductInfo {...productInfo} />
+					</Tab>
+					<Tab label="Alerts" icon={<FontAwesomeIcon icon={faWarning} />}>
+						Alerts TODO
+					</Tab>
+					<Tab label="Download" icon={<FontAwesomeIcon icon={faDownload} />}>
+						Download / Save Gif TODO
+					</Tab>
+				</Tabs>
+			</div>
+			<MobileIconNav tab />
+		</>
+	)
+}
+
+export default ForecastAnimator

--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -82,7 +82,7 @@ export const Animator = ({
 	const closeMobileSidebarMenu = useRootStore.use.closeMobileSidebarMenu()
 	const [loadedFrames, setLoadedFrames] = useState([])
 	const [overlayPanelOpen, setOverlayPanelOpen] = useState(false)
-	const [currentFrame, setCurrentFrame] = useState(startFrame || frames.length - 1)
+	const [currentFrame, setCurrentFrame] = useState(startFrame !== undefined ? startFrame : frames.length - 1)
 	const [loopMethod, setLoopMethod] = useState(LoopMethod.LeftToRight)
 	const [playDirection, setPlayDirection] = useState<direction>(1)
 	const [isPlaying, setIsPlaying] = useState(false)
@@ -177,11 +177,9 @@ export const Animator = ({
 	}, [autoPlay, loadedFrames])
 
 	useEffect(() => {
-		if (!startFrame && loadedFrames.length > 0) {
-			// if no startFrame is set, default to the last frame
+		if (startFrame === undefined && loadedFrames.length > 0) {
 			setCurrentFrame(loadedFrames.length - 1)
 		} else if (loadedFrames.length > 0) {
-			// if startFrame is greater than the number of loaded frames, set it to 0
 			setCurrentFrame(startFrame > loadedFrames.length - 1 ? loadedFrames.length - 1 : startFrame)
 		}
 	}, [loadedFrames, startFrame])

--- a/src/data/mobileMenuItems.ts
+++ b/src/data/mobileMenuItems.ts
@@ -18,7 +18,7 @@ export const mobileMenuItems: MenuItemProps[] = [
 	{ id: '4', parentId: '1', title: 'Analysis', url: '/analysis', target: LinkTarget.self },
 	{ id: '3', parentId: '1', title: 'Satellite & Radar', url: '/satellite-mosaic-radar', target: LinkTarget.self },
 	{ id: '5', parentId: '1', title: 'NEXRAD Dual-Pol', url: '/nexrad-dual-pol-radar', target: LinkTarget.self },
-	// { id: '6', parentId: '1', title: 'Forecast Models', url: '/forecast-models', target: LinkTarget.self },
+	{ id: '6', parentId: '1', title: 'Forecast Models', url: '/forecast-models', target: LinkTarget.self },
 	{ id: '7', parentId: '1', title: 'Text & Outlooks', url: '/text-hazards-outlooks', target: LinkTarget.self },
 	{ id: '8', parentId: '4', title: 'Surface Maps', url: '/surface-maps', target: LinkTarget.self },
 	// { id: '9', parentId: '8', title: 'Raw METARS', url: '/raw-metar-observations', target: LinkTarget.self },

--- a/src/store/forecastSlice.ts
+++ b/src/store/forecastSlice.ts
@@ -1,0 +1,52 @@
+import { zoomState } from '@/types/general'
+import { ZustandStateSlice } from './useRootStore'
+
+const defaultForecastZoomState = {
+	positionX: 0,
+	positionY: 0,
+	scale: 1,
+}
+
+export interface IForecastSlice {
+	// forecastNumberOfFrames: number
+	// setForecastNumberOfFrames: (frames: number) => void
+	forecastFrameRate: number
+	setForecastFrameRate: (frameRate: number) => void
+	forecastZoomState: zoomState
+	setForecastZoomState: (zoomState: zoomState) => void
+	resetForecastZoomState: () => void
+	forecastZoomFill: boolean
+	setForecastZoomFill: (zoomFill: boolean) => void
+	forecastDataRefreshInterval: number
+	forecastDataRefreshActive: boolean
+	setForecastDataRefreshInterval: (interval: number) => void
+	setForecastDataRefreshActive: (active: boolean) => void
+	forecastMapFullScreen: boolean
+	setForecastMapFullScreen: (fullScreen: boolean) => void
+	forecastLastFrameDwell: boolean
+	setForecastLastFrameDwell: (dwell: boolean) => void
+	forecastLastFrameDwellTime?: number
+	setForecastLastFrameDwellTime?: (dwellTime: number) => void
+}
+
+export const createForecastSlice: ZustandStateSlice<IForecastSlice> = (set) => ({
+	// forecastNumberOfFrames: 24,
+	// setForecastNumberOfFrames: (frames: number) => set(() => ({ forecastNumberOfFrames: frames })),
+	forecastFrameRate: 10,
+	setForecastFrameRate: (frameRate: number) => set(() => ({ forecastFrameRate: frameRate })),
+	forecastZoomState: { ...defaultForecastZoomState },
+	setForecastZoomState: (forecastZoomState) => set(() => ({ forecastZoomState })),
+	resetForecastZoomState: () => set(() => ({ forecastZoomState: { ...defaultForecastZoomState } })),
+	forecastZoomFill: false,
+	setForecastZoomFill: (zoomFill: boolean) => set(() => ({ forecastZoomFill: zoomFill })),
+	forecastDataRefreshInterval: 5,
+	setForecastDataRefreshInterval: (interval: number) => set(() => ({ forecastDataRefreshInterval: interval })),
+	forecastDataRefreshActive: true,
+	setForecastDataRefreshActive: (active: boolean) => set(() => ({ forecastDataRefreshActive: active })),
+	forecastMapFullScreen: false,
+	setForecastMapFullScreen: (fullScreen) => set({ forecastMapFullScreen: fullScreen }),
+	forecastLastFrameDwell: true,
+	setForecastLastFrameDwell: (dwell: boolean) => set(() => ({ forecastLastFrameDwell: dwell })),
+	forecastLastFrameDwellTime: 1,
+	setForecastLastFrameDwellTime: (dwellTime: number) => set(() => ({ forecastLastFrameDwellTime: dwellTime })),
+})

--- a/src/store/useRootStore.ts
+++ b/src/store/useRootStore.ts
@@ -2,6 +2,7 @@ import { enableMapSet } from 'immer'
 import { StateCreator, create } from 'zustand'
 import { IAnalysisSlice, createAnalysisSlice } from './analysisSlice'
 import createSelectors from './createSelectors'
+import { IForecastSlice, createForecastSlice } from './forecastSlice'
 import { IGlobalSettingsSlice, createGlobalSettingsSlice } from './globalSettingsSlice'
 import { IHazardsSlice, createHazardsSlice } from './hazardsSlice'
 import { IMobileMenuSlice, createMobileMenuSlice } from './mobileMenuSlice'
@@ -20,6 +21,7 @@ export interface IGlobalStore
 		IGlobalSettingsSlice,
 		INexradSlice,
 		ISatradSlice,
+		IForecastSlice,
 		IAnalysisSlice {}
 
 export type ZustandStateSlice<T> = StateCreator<IGlobalStore, [], [], T>
@@ -32,6 +34,7 @@ const useRootStoreBase = create<IGlobalStore>((...args) => ({
 	...createGlobalSettingsSlice(...args),
 	...createNexradSlice(...args),
 	...createSatradSlice(...args),
+	...createForecastSlice(...args),
 	...createAnalysisSlice(...args),
 }))
 

--- a/src/util/dataCalls/forecast/query-forecast.ts
+++ b/src/util/dataCalls/forecast/query-forecast.ts
@@ -1,6 +1,6 @@
 import { getData } from '../dataCall'
 
 export const getForecastData = async (model, run, sector, level, product) => {
-	const endpoint = `https://weather.cod.edu/datapoints/satrad/get-files.php?parms=${model}-${run}-${sector}-${level}-${product}`
+	const endpoint = `https://weather.cod.edu/datapoints/forecast/get-files.php?parms=${model}-${run}-${sector}-${level}-${product}`
 	return await getData(endpoint)
 }

--- a/src/util/weatherDataPageLookup.ts
+++ b/src/util/weatherDataPageLookup.ts
@@ -361,6 +361,13 @@ export const getSatradPageIdByProductId = (productId) => {
 			return null
 	}
 }
+export const getForecastPageIdByParams = (modelId, levelId, productId) => {
+	// we need to discuss whether this is stored in strapi; if so how? It'd be 100+ entries so plan for that
+	console.log('meta needs defining', modelId, levelId, productId)
+	// in lieu of meta, will always return home page id for now
+	return 'gxhgxxjlq57yz9wrcf1djtwb'
+}
+
 export const getDataPageIdByProductId = (productId) => {
 	switch (productId) {
 		case NEXRAD_PRODUCT_BASEREF_0_5:


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 9368268923

## Description
Rather that pushing this any further than basic functionality; I'm just going to submit this for review now. I've compiled a list of known objectives we need the page to reach. Several of them feel like we need to talk them through a bit and decide what is essential in order to move forward, and what can be backlogged.

### What we need for the forecast page
- ability to manipulate model run
- `auto-refresh` needs to be able to handle 2 different behaviors; if viewing "current" run and said run is not 100% complete, check for more images. If viewing "non-current" run or "current" run while 100% complete, check for new runs. Likely this might mean some additional data coming out of the API endpoint so that the animator can handle this all on its own.
- plot float sectors on map (requires fetch of coordinates from weather.cod.edu)
- Need to handle large sectors appropriately; either create second map (think region or scale) for big sectors (`WLD`,`NA`,`PO`,`AO`, etc) or consider new `Text` type of sector where instead of drawing them on the d3map, the SectorSelect component is outfitted with a div to populate with standard links. Which is better?
- group menu accordions so that only one is open at a time
- independently assign defaults for `sector`, `level` and `product`. Right now when switching models, if `sector` does not exist for selected `model` then `sector`, `level`, `product` all resort to defaults for said `model`
- attempt "smarter" defaults `sector`, and `level`+`product`. The current site has this to some limited extent; essentially if a `level+product` doesn't exist for the model or sector you just chose then make an attempt to choose something similar before using a last resort default. Same goes for sectors, which I've carried over and defined "alternate" sectors in the data objects to implement, but have not made use of them yet.
- retain `currentFrame` value when switching sector and products. Smartest way to achieve this might be by tracking valid time of the current frame so that we could also attempt to preserve an appropriate current frame when switching models. Additionally; this approach would work for preserving current frame for other animators. However the easy option is just preserving/globalizing the `currentFrame`.
- Product descriptions: do we still let strapi handle this? There could be ~150-200 descriptions that would need to be created. There are 114 model products, a relatively small subset of which occur across multiple levels which slightly alters how the product should be described; similarly some products have subtle differences across different models. Much of this content (and the logic to handle the variations) exists already on the current site, but we should decide if/where this reside on the new site.
- Mouseover Data readouts
- Forecast soundings
- Comparisons

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run dev` and `npm run build`

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):
![image](https://github.com/user-attachments/assets/6a518b67-5f01-4f68-846a-06c4d5d5cf8c)

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
