### PR TITLE
Forecast Height Comparison Sidebar

### DIFF
--- a/src/components/elements/Select/Select.module.scss
+++ b/src/components/elements/Select/Select.module.scss
@@ -67,6 +67,22 @@
 	margin-bottom: 20px;
 	background-color: var(--color-grey19);
 	transition: all var(--themeChange);
+
+	.option {
+		padding: 10px;
+		transition: all 0.2s ease-out;
+		font-size: 16px;
+		color: var(--color-grey3);
+
+		&:hover {
+			background-color: var(--color-blue3);
+			color: var(--color-white);
+		}
+
+		&:last-child {
+			border-bottom: 0;
+		}
+	}
 }
 .arrow {
 	color: var(--color-grey10);
@@ -75,21 +91,5 @@
 	top: 10px;
 	svg {
 		display: block;
-	}
-}
-
-.option {
-	padding: 10px;
-	transition: all 0.2s ease-out;
-	font-size: 16px;
-	color: var(--color-grey3);
-
-	&:hover {
-		background-color: var(--color-blue3);
-		color: var(--color-white);
-	}
-
-	&:last-child {
-		border-bottom: 0;
 	}
 }

--- a/src/components/elements/Select/Select.tsx
+++ b/src/components/elements/Select/Select.tsx
@@ -21,7 +21,7 @@ interface SelectProps {
 
 const Select: React.FC<SelectProps> = ({ value, options, onChange, title = null, placeholder = '', optionsEmptyText = 'No options' }) => {
 	const [open, setOpen] = useState(false)
-	const wrapperRef = useRef(null)
+	const wrapperRef = useRef<HTMLDivElement | null>(null)
 	// Random number gen for Unique ID for any instance of Select, used to handle open/close events
 	const idRef = useRef<string>(Math.random().toString(36).slice(2))
 
@@ -79,7 +79,7 @@ const Select: React.FC<SelectProps> = ({ value, options, onChange, title = null,
 	}
 
 	return (
-		<div className={styles.wrapper}>
+		<div ref={wrapperRef} className={styles.wrapper}>
 			{title && <span className={styles.title}>{title}</span>}
 			<div className={`${styles.select} ${title ? styles.withTitle : ''}`} onClick={toggleOpen}>
 				{!foundValue && placeholder && <label>{placeholder}</label>}

--- a/src/components/elements/Select/Select.tsx
+++ b/src/components/elements/Select/Select.tsx
@@ -22,6 +22,8 @@ interface SelectProps {
 const Select: React.FC<SelectProps> = ({ value, options, onChange, title = null, placeholder = '', optionsEmptyText = 'No options' }) => {
 	const [open, setOpen] = useState(false)
 	const wrapperRef = useRef(null)
+	// Random number gen for Unique ID for any instance of Select, used to handle open/close events
+	const idRef = useRef<string>(Math.random().toString(36).slice(2))
 
 	const handleClickOutside = (event) => {
 		if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
@@ -38,8 +40,18 @@ const Select: React.FC<SelectProps> = ({ value, options, onChange, title = null,
 
 	useEffect(() => {
 		document.addEventListener('click', handleClickOutside)
+		const handleOtherOpen = (e: Event) => {
+			try {
+				const detail = (e as CustomEvent).detail
+				if (detail !== idRef.current) setOpen(false)
+			} catch (e) {
+				// ignore
+			}
+		}
+		document.addEventListener('select-open', handleOtherOpen as EventListener)
 		return () => {
 			document.removeEventListener('click', handleClickOutside)
+			document.removeEventListener('select-open', handleOtherOpen as EventListener)
 		}
 	}, [])
 
@@ -54,10 +66,22 @@ const Select: React.FC<SelectProps> = ({ value, options, onChange, title = null,
 
 	const foundValue = options.find((option) => option.value === value)
 
+	const toggleOpen = () => {
+		if (!open) {
+			// notify other selects that this one is opening
+			try {
+				document.dispatchEvent(new CustomEvent('select-open', { detail: idRef.current }))
+			} catch (e) {
+				// ignore in environments that don't support CustomEvent
+			}
+		}
+		setOpen((prevOpen) => !prevOpen)
+	}
+
 	return (
 		<div className={styles.wrapper}>
 			{title && <span className={styles.title}>{title}</span>}
-			<div className={`${styles.select} ${title ? styles.withTitle : ''}`} onClick={() => setOpen((prevOpen) => !prevOpen)}>
+			<div className={`${styles.select} ${title ? styles.withTitle : ''}`} onClick={toggleOpen}>
 				{!foundValue && placeholder && <label>{placeholder}</label>}
 				{foundValue && foundValue.label && <div className={styles.value}>{foundValue.label}</div>}
 

--- a/src/components/elements/ValidtimeSelect/ValidtimeSelect.module.scss
+++ b/src/components/elements/ValidtimeSelect/ValidtimeSelect.module.scss
@@ -1,0 +1,188 @@
+.wrapper {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 10px;
+	&:has(.title) {
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+	}
+}
+
+.select {
+	cursor: pointer;
+	position: static;
+	display: flex;
+	align-items: center;
+	padding-right: 8px;
+	border-radius: 4px;
+	height: 40px;
+	width: 100%;
+	background-color: var(--color-grey19);
+	border: 1px solid var(--color-grey14);
+	transition: all var(--themeChange);
+
+	&.withTitle {
+		width: 70%;
+	}
+
+	label {
+		font-size: 16px;
+		color: var(--color-grey3);
+		position: absolute;
+		left: 5px;
+		top: 6px;
+		transform: translate(11px, 9px);
+		transition: all linear 0.12s;
+		z-index: 0;
+	}
+}
+.title {
+	width: 30%;
+	flex-shrink: 0;
+	font-size: 14px;
+}
+.value {
+	color: var(--color-grey4-grey3);
+	transition: color var(--themeChange);
+	font-size: 16px;
+	height: 35px;
+	width: 100%;
+	padding: 16px;
+	display: flex;
+	align-content: center;
+	flex-direction: column;
+	justify-content: center;
+}
+
+.options {
+	width: 100%;
+	z-index: 500;
+	position: absolute;
+	top: 38px;
+	left: 0;
+	border-radius: 0 0 4px 4px;
+	border: 1px solid var(--color-grey14);
+	border-top: 0px;
+	filter: drop-shadow(0px 4px 14px rgba(0, 0, 0, 0.11));
+	margin-bottom: 20px;
+	background-color: var(--color-grey19);
+	transition: all var(--themeChange);
+
+	/* cap the menu height and let the ScrollArea child handle scrolling */
+	max-height: 300px;
+	overflow: hidden;
+	> * {
+		max-height: 300px;
+		overflow: auto;
+	}
+
+	.option {
+		font-family: monospace;
+		padding: 6px;
+		transition: all 0.2s ease-out;
+		font-size: 12px;
+		color: var(--color-grey3);
+		border: 1px solid var(--color-grey15);
+		background-color: var(--color-grey18);
+
+		&:hover {
+			background-color: var(--color-blue3);
+			color: var(--color-white);
+		}
+
+		&:last-child {
+			border-bottom: 0;
+		}
+	}
+
+	/* selected state styling */
+	.option.selected,
+	.option[aria-selected='true'] {
+		background-color: var(--color-blue3);
+		color: var(--color-white);
+	}
+}
+.grid {
+	display: grid;
+	grid-template-columns: repeat(6, 1fr);
+	gap: 6px;
+	align-items: center;
+	justify-items: stretch;
+	padding: 6px;
+	> .option {
+		padding: 8px 6px;
+		text-align: center;
+		border-radius: 4px;
+	}
+}
+.group {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 6px 8px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.02);
+}
+.groupTitle {
+	font-size: 12px;
+	color: var(--color-grey6);
+	padding: 2px 6px;
+}
+.arrow {
+	color: var(--color-grey10);
+	position: static;
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	svg {
+		display: block;
+	}
+}
+
+/* layout for the select with navigation buttons */
+.selectRow {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	position: relative; /* anchor dropdown to the full row so it can span the sidebar */
+}
+
+.navButton {
+	background: transparent;
+	border: 1px solid transparent;
+	color: var(--color-grey8);
+	width: 34px;
+	height: 34px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 4px;
+	cursor: pointer;
+	transition:
+		background-color 0.12s ease,
+		color 0.12s ease;
+
+	&:hover {
+		background-color: var(--color-grey17);
+		color: var(--color-white);
+	}
+
+	&:disabled {
+		opacity: 0.45;
+		cursor: default;
+		background: transparent;
+		color: var(--color-grey6);
+	}
+}
+
+.selectRow .select {
+	min-width: 0; /* allow flex children to shrink properly */
+	flex: 1 1 auto;
+	width: 0; /* needed to ensure flex growth without overflowing */
+}
+
+/* removed bottom .options override so the primary .options rule above controls positioning and width */

--- a/src/components/elements/ValidtimeSelect/ValidtimeSelect.tsx
+++ b/src/components/elements/ValidtimeSelect/ValidtimeSelect.tsx
@@ -1,0 +1,273 @@
+import ScrollArea from '@/components/layout/ScrollArea/ScrollArea'
+import { faChevronDown, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { motion } from 'framer-motion'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import styles from './ValidtimeSelect.module.scss'
+
+export interface Option {
+	label?: string
+	value: any
+}
+
+interface SelectProps {
+	value: any
+	// options can be either a flat array or grouped by date
+	options: Option[] | Array<{ title: string; options: Option[] }>
+	onChange: (value: any) => void
+	title?: string | null
+	placeholder?: string
+	optionsEmptyText?: string
+}
+
+const ValidtimeSelect: React.FC<SelectProps> = ({ value, options, onChange, title = null, placeholder = '', optionsEmptyText = 'No options' }) => {
+	const [open, setOpen] = useState(false)
+	const wrapperRef = useRef<HTMLDivElement | null>(null)
+	// Random number gen for Unique ID for any instance of Select, used to handle open/close events
+	const idRef = useRef<string>(Math.random().toString(36).slice(2))
+
+	const handleClickOutside = (event: any) => {
+		if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+			setOpen(false)
+		}
+	}
+
+	const optionSelected = useMemo(() => {
+		return (event: any, selectedOption: Option) => {
+			event.stopPropagation()
+			if (selectedOption && selectedOption.value !== undefined) onChange(selectedOption.value)
+			setOpen(false)
+		}
+	}, [onChange])
+
+	useEffect(() => {
+		document.addEventListener('click', handleClickOutside)
+		const handleOtherOpen = (e: Event) => {
+			try {
+				const detail = (e as CustomEvent).detail
+				if (detail !== idRef.current) setOpen(false)
+			} catch (e) {
+				// ignore
+			}
+		}
+		document.addEventListener('select-open', handleOtherOpen as EventListener)
+		return () => {
+			document.removeEventListener('click', handleClickOutside)
+			document.removeEventListener('select-open', handleOtherOpen as EventListener)
+		}
+	}, [])
+
+	// no normalization effect here; grouping happens below and selection is based on grouped options
+
+	let foundValue: Option | undefined = undefined
+
+	const toggleOpen = () => {
+		if (!open) {
+			// notify other selects that this one is opening
+			try {
+				document.dispatchEvent(new CustomEvent('select-open', { detail: idRef.current }))
+			} catch (e) {
+				// ignore in environments that don't support CustomEvent
+			}
+		}
+		setOpen((prevOpen) => !prevOpen)
+	}
+
+	// formatter for unix timestamps into 'HHZ MM/DD/YY'
+	const formatValidTimeLabel = (ts: string | number) => {
+		const n = Number(ts)
+		if (Number.isNaN(n)) return String(ts)
+		const ms = n > 1e12 ? n : n * 1000
+		const d = new Date(ms)
+		const hh = String(d.getUTCHours()).padStart(2, '0')
+		const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+		const dd = String(d.getUTCDate()).padStart(2, '0')
+		const yy = String(d.getUTCFullYear() % 100).padStart(2, '0')
+		return `${hh}Z ${mm}/${dd}/${yy}`
+	}
+
+	const isGrouped = Array.isArray(options) && options.length && (options[0] as any).options
+	const flatOptions: Option[] = useMemo(() => (!isGrouped && Array.isArray(options) ? (options as Option[]) : []), [options, isGrouped])
+
+	const groupedOptions = useMemo(() => {
+		if (isGrouped) return options as Array<{ title: string; options: Option[] }>
+		const groups = new Map<string, Option[]>()
+		flatOptions.forEach((opt) => {
+			const formatted = opt.label ?? formatValidTimeLabel(opt.value)
+			const parts = String(formatted).split(' ')
+			const datePart = parts.slice(1).join(' ') || ''
+			const hhz = parts[0] || String(formatted)
+			const displayOpt: Option = { value: opt.value, label: hhz }
+			if (!groups.has(datePart)) groups.set(datePart, [])
+			groups.get(datePart)!.push(displayOpt)
+		})
+		return Array.from(groups.entries()).map(([, opts]) => ({
+			title: opts.length ? String(formatValidTimeLabel(opts[0].value)).split(' ').slice(1).join(' ') : '',
+			options: opts,
+		}))
+	}, [options, flatOptions, isGrouped])
+
+	// find the selected value in groupedOptions first, then fall back to flatOptions
+	if (groupedOptions && groupedOptions.length) {
+		outer: for (const grp of groupedOptions) {
+			for (const o of grp.options) {
+				if (String(o.value) === String(value)) {
+					foundValue = o
+					break outer
+				}
+			}
+		}
+	}
+	if (!foundValue && flatOptions && flatOptions.length) {
+		const m = flatOptions.find((o) => String(o.value) === String(value))
+		if (m) {
+			// ensure label is HHZ for display
+			foundValue = { value: m.value, label: m.label ?? String(formatValidTimeLabel(m.value)).split(' ')[0] }
+		}
+	}
+
+	const optionsContent = useMemo(() => {
+		if (groupedOptions && groupedOptions.length) {
+			return groupedOptions.map((grp, gi) => (
+				<div className={styles.group} key={gi}>
+					<div className={styles.groupTitle}>{grp.title}</div>
+					<div className={styles.grid}>
+						{grp.options.map((option, index) => (
+							<div
+								data-value={String(option.value)}
+								className={`${styles.option} ${String(option.value) === String(value) ? styles.selected : ''}`}
+								key={index}
+								onClick={(event) => optionSelected(event, option)}
+								aria-selected={String(option.value) === String(value)}
+							>
+								{option.label}
+							</div>
+						))}
+					</div>
+				</div>
+			))
+		}
+		if (flatOptions.length) {
+			return (
+				<div className={styles.grid}>
+					{flatOptions.map((opt, index) => {
+						const label = opt.label ?? String(formatValidTimeLabel(opt.value)).split(' ')[0]
+						return (
+							<div
+								data-value={String(opt.value)}
+								className={`${styles.option} ${String(opt.value) === String(value) ? styles.selected : ''}`}
+								key={index}
+								onClick={(event) => optionSelected(event, { ...opt, label })}
+								aria-selected={String(opt.value) === String(value)}
+							>
+								{label}
+							</div>
+						)
+					})}
+				</div>
+			)
+		}
+		return <div className={styles.option}>{optionsEmptyText}</div>
+	}, [groupedOptions, flatOptions, optionsEmptyText, optionSelected, value])
+
+	// flattened ordered values (strings) for prev/next navigation
+	const orderedValues = useMemo(() => {
+		if (groupedOptions && groupedOptions.length) {
+			const vals: string[] = []
+			for (const grp of groupedOptions) {
+				for (const o of grp.options) vals.push(String(o.value))
+			}
+			return vals
+		}
+		return flatOptions.map((o) => String(o.value))
+	}, [groupedOptions, flatOptions])
+
+	const handlePrevClick = (e: any) => {
+		e.stopPropagation()
+		if (!orderedValues || orderedValues.length === 0) return
+		const idx = orderedValues.findIndex((v) => String(v) === String(value))
+		if (idx > 0) {
+			onChange(orderedValues[idx - 1])
+		}
+	}
+
+	const handleNextClick = (e: any) => {
+		e.stopPropagation()
+		if (!orderedValues || orderedValues.length === 0) return
+		const idx = orderedValues.findIndex((v) => String(v) === String(value))
+		if (idx >= 0 && idx < orderedValues.length - 1) {
+			onChange(orderedValues[idx + 1])
+		}
+	}
+
+	// when opened, scroll the selected option's group into view at the top so the group heading is visible
+	useEffect(() => {
+		if (!open) return
+		try {
+			const root = wrapperRef.current
+			if (!root) return
+			const selector = `[data-value='${String(value)}']`
+			const el = root.querySelector(selector) as HTMLElement | null
+			if (!el) return
+			// try to find the nearest group container and scroll it to the top of the scroll area
+			const groupEl = el.closest(`.${styles.group}`) as HTMLElement | null
+			if (groupEl && typeof groupEl.scrollIntoView === 'function') {
+				groupEl.scrollIntoView({ block: 'start' })
+				return
+			}
+			// fallback: scroll the option itself to the start
+			if (typeof el.scrollIntoView === 'function') {
+				el.scrollIntoView({ block: 'start' })
+			}
+		} catch (e) {
+			// ignore any query/scroll errors
+		}
+	}, [open, value])
+
+	return (
+		<div ref={wrapperRef} className={styles.wrapper}>
+			{title && <span className={styles.title}>{title}</span>}
+			<div className={styles.selectRow}>
+				<button
+					type="button"
+					className={styles.navButton}
+					onClick={handlePrevClick}
+					aria-label="Previous valid time"
+					disabled={orderedValues.findIndex((v) => String(v) === String(value)) <= 0}
+				>
+					<FontAwesomeIcon icon={faChevronLeft} />
+				</button>
+
+				<div className={`${styles.select} ${title ? styles.withTitle : ''}`} onClick={toggleOpen}>
+					{!foundValue && placeholder && <label>{placeholder}</label>}
+					{foundValue && <div className={styles.value}>{String(formatValidTimeLabel(foundValue.value))}</div>}
+
+					<motion.div className={styles.arrow} animate={{ transform: `${open ? 'rotate(180deg)' : 'rotate(0deg)'}` }}>
+						<FontAwesomeIcon icon={faChevronDown} />
+					</motion.div>
+
+					{open && (
+						<div className={styles.options}>
+							<ScrollArea>{optionsContent}</ScrollArea>
+						</div>
+					)}
+				</div>
+
+				<button
+					type="button"
+					className={styles.navButton}
+					onClick={handleNextClick}
+					aria-label="Next valid time"
+					disabled={
+						orderedValues.findIndex((v) => String(v) === String(value)) < 0 ||
+						orderedValues.findIndex((v) => String(v) === String(value)) >= orderedValues.length - 1
+					}
+				>
+					<FontAwesomeIcon icon={faChevronRight} />
+				</button>
+			</div>
+		</div>
+	)
+}
+
+export default ValidtimeSelect

--- a/src/components/elements/ValidtimeSelectPanel/ValidtimeSelectPanel.module.scss
+++ b/src/components/elements/ValidtimeSelectPanel/ValidtimeSelectPanel.module.scss
@@ -1,0 +1,99 @@
+.wrapper {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	&:has(.title) {
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+	}
+}
+.title {
+	width: 30%;
+	flex-shrink: 0;
+	font-size: 14px;
+}
+.value {
+	color: var(--color-grey4-grey3);
+	transition: color var(--themeChange);
+	font-size: 16px;
+	height: 35px;
+	width: 100%;
+	padding: 16px;
+	display: flex;
+	align-content: center;
+	flex-direction: column;
+	justify-content: center;
+}
+.options {
+	width: 100%;
+	background-color: transparent;
+	max-height: 500px; /* allow the sidebar to scroll the panel if needed */
+	overflow: auto;
+
+	.option {
+		font-family: monospace;
+		transition: all 0.12s ease-out;
+		font-size: 12px;
+		color: var(--color-grey3);
+		border: 1px solid var(--color-grey15);
+		background-color: var(--color-grey18);
+		border-radius: 4px;
+
+		&:hover {
+			background-color: var(--color-blue3);
+			color: var(--color-white);
+		}
+	}
+
+	/* selected state styling */
+	.option.selected,
+	.option[aria-selected='true'] {
+		background-color: var(--color-blue3);
+		color: var(--color-white);
+	}
+}
+.grid {
+	display: grid;
+	gap: 6px;
+	align-items: center;
+	justify-items: stretch;
+
+	&.rows-4 {
+		grid-template-columns: repeat(4, 1fr);
+	}
+	&.rows-6 {
+		grid-template-columns: repeat(6, 1fr);
+	}
+
+	> .option {
+		padding: 8px 6px;
+		text-align: center;
+		border-radius: 4px;
+	}
+}
+.group {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 6px 0;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.02);
+}
+.groupTitle {
+	font-size: 12px;
+	color: var(--color-grey6);
+	padding: 2px 0;
+}
+.arrow {
+	color: var(--color-grey10);
+	position: static;
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	svg {
+		display: block;
+	}
+}
+/* layout note: panel renders options inline; nav and dropdown styles removed */

--- a/src/components/elements/ValidtimeSelectPanel/ValidtimeSelectPanel.tsx
+++ b/src/components/elements/ValidtimeSelectPanel/ValidtimeSelectPanel.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useMemo, useRef } from 'react'
+import styles from './ValidtimeSelectPanel.module.scss'
+
+export interface Option {
+	label?: string
+	value: any
+}
+
+interface SelectProps {
+	value: any
+	// options can be either a flat array or grouped by date
+	options: Option[] | Array<{ title: string; options: Option[] }>
+	onChange: (value: any) => void
+	title?: string | null
+	rowCount?: number
+}
+
+const ValidtimeSelectPanel: React.FC<SelectProps> = ({ value, options, onChange, title = null, rowCount = 4 }) => {
+	const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+	// click handler inlined in optionsContent to keep dependencies explicit
+
+	// no normalization effect here; grouping happens below and selection is based on grouped options
+
+	let foundValue: Option | undefined = undefined
+
+	// Panel variant: no dropdown toggle; options are rendered inline
+
+	// formatter for unix timestamps into 'HHZ MM/DD/YY'
+	const formatValidTimeLabel = (ts: string | number) => {
+		const n = Number(ts)
+		if (Number.isNaN(n)) return String(ts)
+		const ms = n > 1e12 ? n : n * 1000
+		const d = new Date(ms)
+		const hh = String(d.getUTCHours()).padStart(2, '0')
+		const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+		const dd = String(d.getUTCDate()).padStart(2, '0')
+		const yy = String(d.getUTCFullYear() % 100).padStart(2, '0')
+		return `${hh}Z ${mm}/${dd}/${yy}`
+	}
+
+	const isGrouped = Array.isArray(options) && options.length && (options[0] as any).options
+	const flatOptions: Option[] = useMemo(() => (!isGrouped && Array.isArray(options) ? (options as Option[]) : []), [options, isGrouped])
+
+	const groupedOptions = useMemo(() => {
+		if (isGrouped) return options as Array<{ title: string; options: Option[] }>
+		const groups = new Map<string, Option[]>()
+		flatOptions.forEach((opt) => {
+			const formatted = opt.label ?? formatValidTimeLabel(opt.value)
+			const parts = String(formatted).split(' ')
+			const datePart = parts.slice(1).join(' ') || ''
+			const hhz = parts[0] || String(formatted)
+			const displayOpt: Option = { value: opt.value, label: hhz }
+			if (!groups.has(datePart)) groups.set(datePart, [])
+			groups.get(datePart)!.push(displayOpt)
+		})
+		return Array.from(groups.entries()).map(([, opts]) => ({
+			title: opts.length ? String(formatValidTimeLabel(opts[0].value)).split(' ').slice(1).join(' ') : '',
+			options: opts,
+		}))
+	}, [options, flatOptions, isGrouped])
+
+	// find the selected value in groupedOptions first, then fall back to flatOptions
+	if (groupedOptions && groupedOptions.length) {
+		outer: for (const grp of groupedOptions) {
+			for (const o of grp.options) {
+				if (String(o.value) === String(value)) {
+					foundValue = o
+					break outer
+				}
+			}
+		}
+	}
+	if (!foundValue && flatOptions && flatOptions.length) {
+		const m = flatOptions.find((o) => String(o.value) === String(value))
+		if (m) {
+			// ensure label is HHZ for display
+			foundValue = { value: m.value, label: m.label ?? String(formatValidTimeLabel(m.value)).split(' ')[0] }
+		}
+	}
+
+	const optionsContent = useMemo(() => {
+		const rowClass = rowCount === 6 ? styles['rows-6'] : styles['rows-4']
+
+		if (groupedOptions && groupedOptions.length) {
+			return groupedOptions.map((grp, gi) => (
+				<div className={styles.group} key={gi}>
+					<div className={styles.groupTitle}>{grp.title}</div>
+					<div className={`${styles.grid} ${rowClass}`}>
+						{grp.options.map((option, index) => (
+							<div
+								data-value={String(option.value)}
+								className={`${styles.option} ${String(option.value) === String(value) ? styles.selected : ''}`}
+								key={index}
+								onClick={(event) => {
+									event.stopPropagation()
+									if (option && option.value !== undefined) onChange(option.value)
+								}}
+								aria-selected={String(option.value) === String(value)}
+							>
+								{option.label}
+							</div>
+						))}
+					</div>
+				</div>
+			))
+		}
+
+		if (flatOptions.length) {
+			return (
+				<div className={`${styles.grid} ${rowClass}`}>
+					{flatOptions.map((opt, index) => {
+						const label = opt.label ?? String(formatValidTimeLabel(opt.value)).split(' ')[0]
+						return (
+							<div
+								data-value={String(opt.value)}
+								className={`${styles.option} ${String(opt.value) === String(value) ? styles.selected : ''}`}
+								key={index}
+								onClick={(event) => {
+									event.stopPropagation()
+									if (opt && opt.value !== undefined) onChange(opt.value)
+								}}
+								aria-selected={String(opt.value) === String(value)}
+							>
+								{label}
+							</div>
+						)
+					})}
+				</div>
+			)
+		}
+
+		return <div className={styles.option}>No options</div>
+	}, [groupedOptions, flatOptions, value, onChange, rowCount])
+
+	// on mount / when value changes, try to scroll the selected option into view
+	useEffect(() => {
+		try {
+			const root = wrapperRef.current
+			if (!root) return
+			const selector = `[data-value='${String(value)}']`
+			const el = root.querySelector(selector) as HTMLElement | null
+			if (!el) return
+			const groupEl = el.closest(`.${styles.group}`) as HTMLElement | null
+			if (groupEl && typeof groupEl.scrollIntoView === 'function') {
+				groupEl.scrollIntoView({ block: 'start' })
+				return
+			}
+			if (typeof el.scrollIntoView === 'function') {
+				el.scrollIntoView({ block: 'start' })
+			}
+		} catch (e) {
+			// ignore
+		}
+	}, [value])
+
+	return (
+		<div ref={wrapperRef} className={styles.wrapper}>
+			{title && <span className={styles.title}>{title}</span>}
+			<div className={styles.options}>{optionsContent}</div>
+		</div>
+	)
+}
+
+export default ValidtimeSelectPanel

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -1,7 +1,17 @@
 'use client'
 
+import { Button } from '@/components/elements/Button/Button'
+import { SectorChangeButton } from '@/components/elements/SectorChangeButton/SectorChangeButton'
+import Select from '@/components/elements/Select/Select'
 import { SidebarSectionHeader } from '@/components/elements/SidebarSectionHeader/SidebarSectionHeader'
-import { useParams } from 'next/navigation'
+import { DEFAULT_FORECAST_MODEL, FORECAST_MODELS } from '@/data/forecast/models'
+import { FORECAST_PRODUCTS } from '@/data/forecast/products'
+import { FORECAST_REGIONS } from '@/data/forecast/regions'
+import { FORECAST_SECTORS } from '@/data/forecast/sectors'
+import { useRootStore } from '@/store/useRootStore'
+import { buildProductsByLevel, fetchFloaterSectorData } from '@/util/forecast/common-functions'
+import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
 import ScrollArea from '../../ScrollArea/ScrollArea'
 import styles from './ForecastCompareHeightSidebarPanel.module.scss'
 
@@ -14,22 +24,162 @@ const ForecastCompareHeightSidebarPanel = () => {
 		fcstProduct: productId,
 		fcstCompareValid: validTimeId,
 	} = useParams()
+	const router = useRouter()
+
+	// root-store hooks used for opening sector picker and wiring the selector panel
+	const openSectorSelectorPanel = useRootStore.use.openSectorSelectorPanel()
+	const closeSectorSelectorPanel = useRootStore.use.closeSectorSelectorPanel()
+	const sectorSelectorPanelIsOpen = useRootStore.use.sectorSelectorPanelIsOpen()
+	const setSectorSelectorSectors = useRootStore.use.setSectorSelectorSectors()
+	const setSectorSelectorD3config = useRootStore.use.setSectorSelectorD3config()
+	const updateOnChangeSectorSelectorSectorHandler = useRootStore.use.updateOnChangeSectorSelectorSectorHandler()
+
+	// keep product entries grouped by level and update whenever model or internal sector change
+	const [sortedProductEntries, setSortedProductEntries] = useState<Array<{ level: string; products: string[] }>>([])
+
+	// internal model id (user can change model in this panel without immediately routing)
+	const [internalModelId, setInternalModelId] = useState<string>(modelId as string)
+
+	// region/sector state (used by the sector selector)
+	const regionInitial = (FORECAST_SECTORS as any)[sectorId as string]?.region || ''
+	const [regionId, setRegionId] = useState<string>(regionInitial)
+
+	// internal sector id (user picks a sector in this panel; we don't immediately route)
+	const [internalSectorId, setInternalSectorId] = useState<string>(sectorId as string)
+
+	useEffect(() => {
+		const entries = buildProductsByLevel((internalModelId as string) || '', (internalSectorId as string) || '')
+		setSortedProductEntries(entries)
+	}, [internalModelId, internalSectorId])
+
+	// when the sector selector slideout opens, populate it with sectors and floater data
+	useEffect(() => {
+		if (sectorSelectorPanelIsOpen) {
+			const loadSectorData = async () => {
+				const region = (FORECAST_REGIONS as any)[regionId as string]
+				const newD3config = {
+					rotate: region?.rotate,
+					scale: region?.scale,
+				}
+				setSectorSelectorD3config(newD3config)
+				const updatedSectorData = await fetchFloaterSectorData()
+				const modelKey = (FORECAST_MODELS as any)[internalModelId as string] ? (internalModelId as string) : DEFAULT_FORECAST_MODEL
+				const selectedSectors = (FORECAST_MODELS as any)[modelKey].sectors
+					.filter((sId: string) => (FORECAST_SECTORS as any)[sId].region === regionId)
+					.map((sId: string) => {
+						if (updatedSectorData && updatedSectorData[sId] && updatedSectorData[sId].coordinates) {
+							return {
+								id: sId,
+								...(FORECAST_SECTORS as any)[sId],
+								coordinates: updatedSectorData[sId].coordinates,
+							}
+						}
+						return {
+							id: sId,
+							...(FORECAST_SECTORS as any)[sId],
+						}
+					})
+				setSectorSelectorSectors(selectedSectors)
+			}
+			loadSectorData()
+		}
+	}, [sectorSelectorPanelIsOpen, internalModelId, regionId, setSectorSelectorD3config, setSectorSelectorSectors])
+
+	// wire up handler so when a sector is picked in the selector, we close the panel and navigate
+	useEffect(() => {
+		// when the user selects a sector in the selector, update internal sector id and close the panel
+		updateOnChangeSectorSelectorSectorHandler((newSectorId: string) => {
+			setInternalSectorId(newSectorId)
+			// update region to keep selector in sync
+			setRegionId((FORECAST_SECTORS as any)[newSectorId]?.region || '')
+			closeSectorSelectorPanel()
+		})
+	}, [closeSectorSelectorPanel, updateOnChangeSectorSelectorSectorHandler])
+
+	// derive product options that exist across 2+ levels
+	const productOptions = useMemo(() => {
+		const map = new Map<string, Set<string>>()
+		sortedProductEntries.forEach((entry) => {
+			entry.products.forEach((p) => {
+				const set = map.get(p) ?? new Set<string>()
+				set.add(entry.level)
+				map.set(p, set)
+			})
+		})
+		const candidates = Array.from(map.entries())
+			.filter(([, levels]) => levels.size >= 2)
+			.map(([productId]) => ({ value: productId, label: (FORECAST_PRODUCTS as any)[productId]?.name || productId }))
+		if (candidates.length === 0) return [{ value: 'null', label: 'Unavailable' }]
+		return candidates
+	}, [sortedProductEntries])
+
+	const [selectedProduct, setSelectedProduct] = useState<string>(() => {
+		const first = productOptions[0]
+		// prefer the current route product if it exists in options
+		if (productOptions.find((o) => o.value === (productId as string))) return productId as string
+		return first ? first.value : 'null'
+	})
+
+	useEffect(() => {
+		// keep selection in sync if options change and current selection disappears
+		if (!productOptions.find((o) => o.value === selectedProduct)) {
+			setSelectedProduct(productOptions[0]?.value ?? 'null')
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [productOptions])
+
+	const handleRegionChange = (newRegionId: string) => {
+		setRegionId(newRegionId)
+		openSectorSelectorPanel()
+	}
+
+	const handleSectorChangeButton = () => {
+		// open the sector selector so user can pick a sector visually
+		openSectorSelectorPanel()
+	}
+
 	const returnLink = `/weather-data/forecast-models/${runId}/${modelId}/${sectorId}/${levelId}/${productId}`
+
+	const handleLoadComparison = () => {
+		if (selectedProduct === 'null') {
+			alert('No products available for comparison with current parameters chosen. Please adjust and select product.')
+			return
+		}
+		const baseParams = [runId, modelId, internalSectorId, levelId, selectedProduct].join('/')
+		const route = `/weather-data/forecast-models/${baseParams}/compare-height/${validTimeId}`
+		router.push(route)
+	}
 
 	return (
 		<ScrollArea>
 			<div className={styles.ForecastCompareHeightSidebarPanel}>
 				<SidebarSectionHeader name="Return to Forecast Models" linkUrl={returnLink} />
-				<p>Compare Height Sidebar</p>
-				<p>Parameters:</p>
-				<ul>
-					<li>Model: {modelId}</li>
-					<li>Run: {runId}</li>
-					<li>Sector: {sectorId}</li>
-					<li>Level: {levelId}</li>
-					<li>Product: {productId}</li>
-					<li>Valid Time: {validTimeId}</li>
-				</ul>
+				<div className={styles.options}>
+					<label>Model:</label>
+					<Select
+						value={internalModelId}
+						placeholder={internalModelId as string}
+						options={Object.keys(FORECAST_MODELS).map((m) => ({ value: m, label: (FORECAST_MODELS as any)[m].name }))}
+						onChange={(m) => setInternalModelId(m)}
+					/>
+					<label>Sector Size:</label>
+					<Select
+						value={regionId}
+						placeholder={(FORECAST_REGIONS as any)[regionId]?.label ?? ''}
+						options={Object.keys(FORECAST_REGIONS).map((r) => ({ value: r, label: (FORECAST_REGIONS as any)[r].label }))}
+						onChange={handleRegionChange}
+					/>
+					<SectorChangeButton
+						onClick={handleSectorChangeButton}
+						label="Selected Sector:"
+						labelValue={(FORECAST_SECTORS as any)[internalSectorId as string]?.name ?? 'Unknown Sector'}
+					/>
+
+					<label>Product:</label>
+					<Select value={selectedProduct} placeholder={selectedProduct} options={productOptions} onChange={(v) => setSelectedProduct(v)} />
+
+					<Button label="Load Comparison" disabled={false} onClick={handleLoadComparison} />
+				</div>
 			</div>
 		</ScrollArea>
 	)

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Button } from '@/components/elements/Button/Button'
 import { SectorChangeButton } from '@/components/elements/SectorChangeButton/SectorChangeButton'
 import Select from '@/components/elements/Select/Select'
 import { SidebarSectionHeader } from '@/components/elements/SidebarSectionHeader/SidebarSectionHeader'
@@ -9,9 +8,10 @@ import { FORECAST_PRODUCTS } from '@/data/forecast/products'
 import { FORECAST_REGIONS } from '@/data/forecast/regions'
 import { FORECAST_SECTORS } from '@/data/forecast/sectors'
 import { useRootStore } from '@/store/useRootStore'
+import { getCompareHeightData } from '@/util/dataCalls/forecast/query-comparisons'
 import { buildProductsByLevel, fetchFloaterSectorData } from '@/util/forecast/common-functions'
 import { useParams, useRouter } from 'next/navigation'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import ScrollArea from '../../ScrollArea/ScrollArea'
 import styles from './ForecastCompareHeightSidebarPanel.module.scss'
 
@@ -25,6 +25,7 @@ const ForecastCompareHeightSidebarPanel = () => {
 		fcstCompareValid: validTimeId,
 	} = useParams()
 	const router = useRouter()
+	const returnLink = `/weather-data/forecast-models/${runId}/${modelId}/${sectorId}/${levelId}/${productId}`
 
 	// root-store hooks used for opening sector picker and wiring the selector panel
 	const openSectorSelectorPanel = useRootStore.use.openSectorSelectorPanel()
@@ -33,30 +34,27 @@ const ForecastCompareHeightSidebarPanel = () => {
 	const setSectorSelectorSectors = useRootStore.use.setSectorSelectorSectors()
 	const setSectorSelectorD3config = useRootStore.use.setSectorSelectorD3config()
 	const updateOnChangeSectorSelectorSectorHandler = useRootStore.use.updateOnChangeSectorSelectorSectorHandler()
-
-	// keep product entries grouped by level and update whenever model or internal sector change
-	const [sortedProductEntries, setSortedProductEntries] = useState<Array<{ level: string; products: string[] }>>([])
-
 	// models to omit from the Model Select
 	const OMIT_MODELS = ['HRRR', 'NAMNST', 'CFS', 'SREF', 'GEFS']
 	const allowedModelKeys = Object.keys(FORECAST_MODELS).filter((m) => !OMIT_MODELS.includes(m))
-
-	// internal model id (user can change model in this panel without immediately routing)
-	const [internalModelId, setInternalModelId] = useState<string>(() =>
-		allowedModelKeys.includes(modelId as string) ? (modelId as string) : allowedModelKeys[0] ?? (modelId as string),
-	)
-
 	// region/sector state (used by the sector selector)
 	const regionInitial = (FORECAST_SECTORS as any)[sectorId as string]?.region || ''
 	const [regionId, setRegionId] = useState<string>(regionInitial)
+	// keep product entries grouped by level and update whenever model or internal sector change
+	const [sortedProductEntries, setSortedProductEntries] = useState<Array<{ level: string; products: string[] }>>([])
+	const [validtimes, setValidTimes] = useState<string[]>([])
 
-	// internal sector id (user picks a sector in this panel; we don't immediately route)
-	const [internalSectorId, setInternalSectorId] = useState<string>(sectorId as string)
+	const getData = useCallback(async () => {
+		if (!modelId || !runId || !sectorId || !productId || !validTimeId) return
+		const data = await getCompareHeightData(modelId, runId, sectorId, productId, validTimeId)
+		setValidTimes(data.validtimes)
+		const entries = buildProductsByLevel((modelId as string) || '', (sectorId as string) || '')
+		setSortedProductEntries(entries)
+	}, [modelId, sectorId, productId, validTimeId, runId])
 
 	useEffect(() => {
-		const entries = buildProductsByLevel((internalModelId as string) || '', (internalSectorId as string) || '')
-		setSortedProductEntries(entries)
-	}, [internalModelId, internalSectorId])
+		getData()
+	}, [runId, modelId, sectorId, productId, validTimeId, getData])
 
 	// when the sector selector slideout opens, populate it with sectors and floater data
 	useEffect(() => {
@@ -69,7 +67,7 @@ const ForecastCompareHeightSidebarPanel = () => {
 				}
 				setSectorSelectorD3config(newD3config)
 				const updatedSectorData = await fetchFloaterSectorData()
-				const modelKey = (FORECAST_MODELS as any)[internalModelId as string] ? (internalModelId as string) : DEFAULT_FORECAST_MODEL
+				const modelKey = (FORECAST_MODELS as any)[modelId as string] ? (modelId as string) : DEFAULT_FORECAST_MODEL
 				const selectedSectors = (FORECAST_MODELS as any)[modelKey].sectors
 					.filter((sId: string) => (FORECAST_SECTORS as any)[sId].region === regionId)
 					.map((sId: string) => {
@@ -89,18 +87,15 @@ const ForecastCompareHeightSidebarPanel = () => {
 			}
 			loadSectorData()
 		}
-	}, [sectorSelectorPanelIsOpen, internalModelId, regionId, setSectorSelectorD3config, setSectorSelectorSectors])
+	}, [sectorSelectorPanelIsOpen, modelId, regionId, setSectorSelectorD3config, setSectorSelectorSectors])
 
-	// wire up handler so when a sector is picked in the selector, we close the panel and navigate
 	useEffect(() => {
-		// when the user selects a sector in the selector, update internal sector id and close the panel
 		updateOnChangeSectorSelectorSectorHandler((newSectorId: string) => {
-			setInternalSectorId(newSectorId)
-			// update region to keep selector in sync
-			setRegionId((FORECAST_SECTORS as any)[newSectorId]?.region || '')
 			closeSectorSelectorPanel()
+			const baseParams = [runId, modelId, newSectorId, levelId, productId].join('/')
+			router.push(`/weather-data/forecast-models/${baseParams}/compare-height/${validTimeId}`)
 		})
-	}, [closeSectorSelectorPanel, updateOnChangeSectorSelectorSectorHandler])
+	}, [closeSectorSelectorPanel, updateOnChangeSectorSelectorSectorHandler, runId, modelId, levelId, productId, validTimeId, sectorId, router])
 
 	// derive product options that exist across 2+ levels
 	const productOptions = useMemo(() => {
@@ -119,40 +114,35 @@ const ForecastCompareHeightSidebarPanel = () => {
 		return candidates
 	}, [sortedProductEntries])
 
-	const [selectedProduct, setSelectedProduct] = useState<string>(() => {
-		const first = productOptions[0]
-		// prefer the current route product if it exists in options
-		if (productOptions.find((o) => o.value === (productId as string))) return productId as string
-		return first ? first.value : 'null'
-	})
-
-	useEffect(() => {
-		// keep selection in sync if options change and current selection disappears
-		if (!productOptions.find((o) => o.value === selectedProduct)) {
-			setSelectedProduct(productOptions[0]?.value ?? 'null')
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [productOptions])
-
 	const handleRegionChange = (newRegionId: string) => {
 		setRegionId(newRegionId)
 		openSectorSelectorPanel()
 	}
 
 	const handleSectorChangeButton = () => {
-		// open the sector selector so user can pick a sector visually
 		openSectorSelectorPanel()
 	}
 
-	const returnLink = `/weather-data/forecast-models/${runId}/${modelId}/${sectorId}/${levelId}/${productId}`
-
-	const handleLoadComparison = () => {
-		if (selectedProduct === 'null') {
-			alert('No products available for comparison with current parameters chosen. Please adjust and select product.')
-			return
-		}
-		const baseParams = [runId, modelId, internalSectorId, levelId, selectedProduct].join('/')
+	const handleProductChange = (newProductId: string) => {
+		if (!newProductId || newProductId === productId) return
+		console.log('Product changed to:', newProductId)
+		const baseParams = [runId, modelId, sectorId, levelId, newProductId].join('/')
 		const route = `/weather-data/forecast-models/${baseParams}/compare-height/${validTimeId}`
+		router.push(route)
+	}
+
+	const handleModelChange = (newModelId: string) => {
+		if (!newModelId || newModelId === modelId) return
+		console.log('Model changed to:', newModelId)
+		const baseParams = [runId, newModelId, sectorId, levelId, productId].join('/')
+		const route = `/weather-data/forecast-models/${baseParams}/compare-height/${validTimeId}`
+		router.push(route)
+	}
+	const handleValidTimeChange = (newValidTimeId: string) => {
+		if (!newValidTimeId || newValidTimeId === validTimeId) return
+		console.log('Valid Time changed to:', newValidTimeId)
+		const baseParams = [runId, modelId, sectorId, levelId, productId].join('/')
+		const route = `/weather-data/forecast-models/${baseParams}/compare-height/${newValidTimeId}`
 		router.push(route)
 	}
 
@@ -163,10 +153,10 @@ const ForecastCompareHeightSidebarPanel = () => {
 				<div className={styles.options}>
 					<label>Model:</label>
 					<Select
-						value={internalModelId}
-						placeholder={internalModelId as string}
-						options={allowedModelKeys.map((m) => ({ value: m, label: (FORECAST_MODELS as any)[m].name }))}
-						onChange={(m) => setInternalModelId(m)}
+						value={modelId}
+						placeholder={modelId as string}
+						options={allowedModelKeys.map((model) => ({ value: model, label: (FORECAST_MODELS as any)[model].name }))}
+						onChange={(newModelId) => handleModelChange(newModelId)}
 					/>
 					<label>Sector Size:</label>
 					<Select
@@ -178,13 +168,24 @@ const ForecastCompareHeightSidebarPanel = () => {
 					<SectorChangeButton
 						onClick={handleSectorChangeButton}
 						label="Selected Sector:"
-						labelValue={(FORECAST_SECTORS as any)[internalSectorId as string]?.name ?? 'Unknown Sector'}
+						labelValue={(FORECAST_SECTORS as any)[sectorId as string]?.name ?? 'Unknown Sector'}
 					/>
 
 					<label>Product:</label>
-					<Select value={selectedProduct} placeholder={selectedProduct} options={productOptions} onChange={(v) => setSelectedProduct(v)} />
+					<Select
+						value={productId}
+						placeholder={productId as string}
+						options={productOptions}
+						onChange={(newProductId) => handleProductChange(newProductId)}
+					/>
 
-					<Button label="Load Comparison" disabled={false} onClick={handleLoadComparison} />
+					<label>Valid Time:</label>
+					<Select
+						value={validTimeId}
+						placeholder={validTimeId as string}
+						options={validtimes.map((validtime) => ({ value: validtime, label: validtime }))}
+						onChange={(newValidTimeId) => handleValidTimeChange(newValidTimeId)}
+					/>
 				</div>
 			</div>
 		</ScrollArea>

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -3,7 +3,7 @@
 import { SectorChangeButton } from '@/components/elements/SectorChangeButton/SectorChangeButton'
 import Select from '@/components/elements/Select/Select'
 import { SidebarSectionHeader } from '@/components/elements/SidebarSectionHeader/SidebarSectionHeader'
-import ValidtimeSelect from '@/components/elements/ValidtimeSelect/ValidtimeSelect'
+import ValidtimeSelectPanel from '@/components/elements/ValidtimeSelectPanel/ValidtimeSelectPanel'
 import { DEFAULT_FORECAST_MODEL, FORECAST_MODELS } from '@/data/forecast/models'
 import { FORECAST_PRODUCTS } from '@/data/forecast/products'
 import { FORECAST_REGIONS } from '@/data/forecast/regions'
@@ -151,19 +151,19 @@ const ForecastCompareHeightSidebarPanel = () => {
 	}, [sortedProductEntries])
 
 	// format a unix timestamp (seconds or milliseconds) into 'HHZ MM/DD/YY'
-	const formatValidTimeLabel = (ts: string | number) => {
-		const n = Number(ts)
-		if (Number.isNaN(n)) return String(ts)
-		const ms = n > 1e12 ? n : n * 1000
-		const d = new Date(ms)
-		const hh = String(d.getUTCHours()).padStart(2, '0')
-		const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
-		const dd = String(d.getUTCDate()).padStart(2, '0')
-		const yy = String(d.getUTCFullYear() % 100).padStart(2, '0')
-		return `${hh}Z ${mm}/${dd}/${yy}`
-	}
+	// const formatValidTimeLabel = (ts: string | number) => {
+	// 	const n = Number(ts)
+	// 	if (Number.isNaN(n)) return String(ts)
+	// 	const ms = n > 1e12 ? n : n * 1000
+	// 	const d = new Date(ms)
+	// 	const hh = String(d.getUTCHours()).padStart(2, '0')
+	// 	const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+	// 	const dd = String(d.getUTCDate()).padStart(2, '0')
+	// 	const yy = String(d.getUTCFullYear() % 100).padStart(2, '0')
+	// 	return `${hh}Z ${mm}/${dd}/${yy}`
+	// }
 
-	// validtimes are passed as flat options (ValidtimeSelect will group and format labels)
+	// validtimes are passed as flat options (ValidtimeSelectPanel will group and format labels)
 
 	const handleRegionChange = (newRegionId: string) => {
 		setRegionId(newRegionId)
@@ -231,11 +231,11 @@ const ForecastCompareHeightSidebarPanel = () => {
 					/>
 
 					<label>Valid Time:</label>
-					<ValidtimeSelect
+					<ValidtimeSelectPanel
 						value={validTimeId}
-						placeholder={formatValidTimeLabel(validTimeId as string)}
 						options={validtimes.map((vt) => ({ value: String(vt) }))}
 						onChange={(newValidTimeId) => handleValidTimeChange(newValidTimeId)}
+						rowCount={FORECAST_MODELS[modelId as string]?.validPerRow || 4}
 					/>
 				</div>
 			</div>

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -37,8 +37,14 @@ const ForecastCompareHeightSidebarPanel = () => {
 	// keep product entries grouped by level and update whenever model or internal sector change
 	const [sortedProductEntries, setSortedProductEntries] = useState<Array<{ level: string; products: string[] }>>([])
 
+	// models to omit from the Model Select
+	const OMIT_MODELS = ['HRRR', 'NAMNST', 'CFS', 'SREF', 'GEFS']
+	const allowedModelKeys = Object.keys(FORECAST_MODELS).filter((m) => !OMIT_MODELS.includes(m))
+
 	// internal model id (user can change model in this panel without immediately routing)
-	const [internalModelId, setInternalModelId] = useState<string>(modelId as string)
+	const [internalModelId, setInternalModelId] = useState<string>(() =>
+		allowedModelKeys.includes(modelId as string) ? (modelId as string) : allowedModelKeys[0] ?? (modelId as string),
+	)
 
 	// region/sector state (used by the sector selector)
 	const regionInitial = (FORECAST_SECTORS as any)[sectorId as string]?.region || ''
@@ -159,7 +165,7 @@ const ForecastCompareHeightSidebarPanel = () => {
 					<Select
 						value={internalModelId}
 						placeholder={internalModelId as string}
-						options={Object.keys(FORECAST_MODELS).map((m) => ({ value: m, label: (FORECAST_MODELS as any)[m].name }))}
+						options={allowedModelKeys.map((m) => ({ value: m, label: (FORECAST_MODELS as any)[m].name }))}
 						onChange={(m) => setInternalModelId(m)}
 					/>
 					<label>Sector Size:</label>

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -3,6 +3,7 @@
 import { SectorChangeButton } from '@/components/elements/SectorChangeButton/SectorChangeButton'
 import Select from '@/components/elements/Select/Select'
 import { SidebarSectionHeader } from '@/components/elements/SidebarSectionHeader/SidebarSectionHeader'
+import ValidtimeSelect from '@/components/elements/ValidtimeSelect/ValidtimeSelect'
 import { DEFAULT_FORECAST_MODEL, FORECAST_MODELS } from '@/data/forecast/models'
 import { FORECAST_PRODUCTS } from '@/data/forecast/products'
 import { FORECAST_REGIONS } from '@/data/forecast/regions'
@@ -68,10 +69,21 @@ const ForecastCompareHeightSidebarPanel = () => {
 		} else {
 			const data = await getCompareHeightData(sanitizedModelId, sanitizedRunId, sanitizedSectorId, sanitizedProductId, sanitizedValidTimeId)
 			console.log('Comparison Height Data:', data)
+			if (!data.validtimes.includes(sanitizedValidTimeId)) {
+				const closestValidtime = findClosestNumber(Number(sanitizedValidTimeId), data.validtimes)
+				const baseParmsString = `${sanitizedRunId}/${sanitizedModelId}/${sanitizedSectorId}/${levelId}/${sanitizedProductId}`
+				router.push(`/weather-data/forecast-models/${baseParmsString}/compare-height/${closestValidtime}`)
+			}
 			setValidTimes(data.validtimes)
 			setSortedProductEntries(productsByLevel)
 		}
 	}, [modelId, sectorId, productId, runId, validTimeId, levelId, router])
+
+	const findClosestNumber = (num: number, arr: number[]): number => {
+		return arr.reduce((prev, curr) => {
+			return Math.abs(curr - num) < Math.abs(prev - num) ? curr : prev
+		})
+	}
 
 	useEffect(() => {
 		getData()
@@ -137,6 +149,21 @@ const ForecastCompareHeightSidebarPanel = () => {
 	const productOptions = useMemo(() => {
 		return getCompariables(sortedProductEntries)
 	}, [sortedProductEntries])
+
+	// format a unix timestamp (seconds or milliseconds) into 'HHZ MM/DD/YY'
+	const formatValidTimeLabel = (ts: string | number) => {
+		const n = Number(ts)
+		if (Number.isNaN(n)) return String(ts)
+		const ms = n > 1e12 ? n : n * 1000
+		const d = new Date(ms)
+		const hh = String(d.getUTCHours()).padStart(2, '0')
+		const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+		const dd = String(d.getUTCDate()).padStart(2, '0')
+		const yy = String(d.getUTCFullYear() % 100).padStart(2, '0')
+		return `${hh}Z ${mm}/${dd}/${yy}`
+	}
+
+	// validtimes are passed as flat options (ValidtimeSelect will group and format labels)
 
 	const handleRegionChange = (newRegionId: string) => {
 		setRegionId(newRegionId)
@@ -204,10 +231,10 @@ const ForecastCompareHeightSidebarPanel = () => {
 					/>
 
 					<label>Valid Time:</label>
-					<Select
+					<ValidtimeSelect
 						value={validTimeId}
-						placeholder={validTimeId as string}
-						options={validtimes.map((validtime) => ({ value: validtime, label: validtime }))}
+						placeholder={formatValidTimeLabel(validTimeId as string)}
+						options={validtimes.map((vt) => ({ value: String(vt) }))}
 						onChange={(newValidTimeId) => handleValidTimeChange(newValidTimeId)}
 					/>
 				</div>

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -45,12 +45,33 @@ const ForecastCompareHeightSidebarPanel = () => {
 	const [validtimes, setValidTimes] = useState<string[]>([])
 
 	const getData = useCallback(async () => {
-		if (!modelId || !runId || !sectorId || !productId || !validTimeId) return
-		const data = await getCompareHeightData(modelId, runId, sectorId, productId, validTimeId)
-		setValidTimes(data.validtimes)
-		const entries = buildProductsByLevel((modelId as string) || '', (sectorId as string) || '')
-		setSortedProductEntries(entries)
-	}, [modelId, sectorId, productId, validTimeId, runId])
+		const sanitizedModelId = !FORECAST_MODELS[modelId as string] ? DEFAULT_FORECAST_MODEL : modelId
+		const sanitizedSectorId = FORECAST_MODELS[sanitizedModelId as string].sectors.includes(sectorId as string)
+			? sectorId
+			: FORECAST_MODELS[sanitizedModelId as string].defaults.sector
+		const productsByLevel = buildProductsByLevel(sanitizedModelId as string, sanitizedSectorId as string)
+		const productOptions = getCompariables(productsByLevel)
+		const defaultProduct = productOptions[0]?.value || null
+		const sanitizedProductId = productOptions.some((opt) => opt.value === productId) ? productId : defaultProduct
+		// these next two are primarily to prevent URL manipulation from breaking
+		const sanitizedRunId = Number(runId) > 0 && runId.length === 10 ? runId : 0
+		const sanitizedValidTimeId = Number(validTimeId) > 0 ? validTimeId : 0
+		if (
+			sanitizedModelId !== modelId ||
+			sanitizedRunId !== runId ||
+			sanitizedSectorId !== sectorId ||
+			sanitizedProductId !== productId ||
+			sanitizedValidTimeId !== validTimeId
+		) {
+			const baseParmsString = `${sanitizedRunId}/${sanitizedModelId}/${sanitizedSectorId}/${levelId}/${sanitizedProductId}`
+			router.push(`/weather-data/forecast-models/${baseParmsString}/compare-height/${sanitizedValidTimeId}`)
+		} else {
+			const data = await getCompareHeightData(sanitizedModelId, sanitizedRunId, sanitizedSectorId, sanitizedProductId, sanitizedValidTimeId)
+			console.log('Comparison Height Data:', data)
+			setValidTimes(data.validtimes)
+			setSortedProductEntries(productsByLevel)
+		}
+	}, [modelId, sectorId, productId, runId, validTimeId, levelId, router])
 
 	useEffect(() => {
 		getData()
@@ -97,8 +118,7 @@ const ForecastCompareHeightSidebarPanel = () => {
 		})
 	}, [closeSectorSelectorPanel, updateOnChangeSectorSelectorSectorHandler, runId, modelId, levelId, productId, validTimeId, sectorId, router])
 
-	// derive product options that exist across 2+ levels
-	const productOptions = useMemo(() => {
+	const getCompariables = (sortedProductEntries) => {
 		const map = new Map<string, Set<string>>()
 		sortedProductEntries.forEach((entry) => {
 			entry.products.forEach((p) => {
@@ -112,6 +132,10 @@ const ForecastCompareHeightSidebarPanel = () => {
 			.map(([productId]) => ({ value: productId, label: (FORECAST_PRODUCTS as any)[productId]?.name || productId }))
 		if (candidates.length === 0) return [{ value: 'null', label: 'Unavailable' }]
 		return candidates
+	}
+	// derive product options that exist across 2+ levels
+	const productOptions = useMemo(() => {
+		return getCompariables(sortedProductEntries)
 	}, [sortedProductEntries])
 
 	const handleRegionChange = (newRegionId: string) => {

--- a/src/data/forecast/models.ts
+++ b/src/data/forecast/models.ts
@@ -86,6 +86,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 6,
+		validPerRow: 6,
 		allowForecastSounding: false,
 	},
 	[FORECAST_RAP_ID]: {
@@ -115,6 +116,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 6,
 		allowForecastSounding: true,
 	},
 	[FORECAST_NAM_ID]: {
@@ -146,6 +148,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 4,
 		allowForecastSounding: true,
 	},
 	[FORECAST_NAMNST_ID]: {
@@ -175,6 +178,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 6,
 		allowForecastSounding: true,
 	},
 	[FORECAST_RDPS_ID]: {
@@ -203,6 +207,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 6,
 		allowForecastSounding: false,
 	},
 	[FORECAST_GDPS_ID]: {
@@ -222,6 +227,8 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 2,
+		validPerRow: 4,
+		allowForecastSounding: false,
 	},
 	[FORECAST_ECMWF_ID]: {
 		name: 'ECMWF',
@@ -252,6 +259,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 4,
 		allowForecastSounding: false,
 	},
 	[FORECAST_GFS_ID]: {
@@ -287,6 +295,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 4,
 		allowForecastSounding: true,
 	},
 	[FORECAST_CFS_ID]: {
@@ -300,6 +309,8 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_TEMP_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 4,
+		allowForecastSounding: false,
 	},
 	[FORECAST_SREF_ID]: {
 		name: 'SREF',
@@ -320,6 +331,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_CAPE1000_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 4,
 		allowForecastSounding: false,
 	},
 	[FORECAST_GEFS_ID]: {
@@ -345,6 +357,7 @@ export const FORECAST_MODELS = {
 			product: FORECAST_PRODUCT_CAPE1000_ID,
 		},
 		runsPerRow: 4,
+		validPerRow: 4,
 		allowForecastSounding: false,
 	},
 }

--- a/src/util/dataCalls/forecast/query-comparisons.ts
+++ b/src/util/dataCalls/forecast/query-comparisons.ts
@@ -3,6 +3,7 @@ import { getData } from '../dataCall-generic'
 export const getCompareHeightData = async (model, run, sector, product, validtime) => {
 	const params = [model, run, sector, product, validtime].join('-')
 	const endpoint = `https://weather.cod.edu/datapoints/forecast/get-compare-height.php?parms=${params}`
+	console.log('getCompareHeightData endpoint:', endpoint)
 	const data = await getData(endpoint)
 	if (!data.err) {
 		return {

--- a/src/util/dataCalls/forecast/query-comparisons.ts
+++ b/src/util/dataCalls/forecast/query-comparisons.ts
@@ -8,12 +8,14 @@ export const getCompareHeightData = async (model, run, sector, product, validtim
 		return {
 			frames: data.frames,
 			levels: data.levels,
+			validtimes: data.validtimes,
 			imageInfo: data.img,
 		}
 	} else {
 		return {
 			frames: [],
 			levels: [],
+			validtimes: [],
 			imageInfo: { width: 800, height: 600 },
 			error: data.error,
 		}


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 9867565245

## Description
Sidebar for forecast height comparisons in working order. New ValidtimeSelect component created to manage validtime from the sidebar. Some adjustment to existing Select component to improve behavior and re-organize styles. Abandoned idea that this sidebar needed a "Load Comparison" button, with internal state management. Each parameter change updates the route; I think when we plug in the animator this will feel far more appropriate.

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run dev`

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):
<img width="567" height="770" alt="image" src="https://github.com/user-attachments/assets/7130cd0b-a0e0-4d02-944d-24482e06d982" />

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
