### PR TITLE
Add data readouts to Height Comparison Animator (NXL-10084633364)

### DIFF
--- a/src/components/blocks/_animators/ForecastCompareHeightAnimator/ForecastCompareHeightAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareHeightAnimator/ForecastCompareHeightAnimator.tsx
@@ -8,9 +8,10 @@ import { FORECAST_MODELS } from '@/data/forecast/models'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useRootStore } from '@/store/useRootStore'
 import { getCompareHeightData } from '@/util/dataCalls/forecast/query-comparisons'
+import { getFrameReadoutData } from '@/util/dataCalls/forecast/query-readout'
 import { getModelRuns } from '@/util/dataCalls/forecast/query-runs'
 import { useParams, usePathname, useRouter } from 'next/navigation'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ForecastCompareHeightAnimatorSettings from '../../_animatorSettingPanels/ForecastCompareHeightAnimatorSettings/ForecastCompareHeightAnimatorSettings'
 import styles from './ForecastCompareHeightAnimator.module.scss'
 
@@ -45,6 +46,10 @@ const ForecastCompareHeightAnimator: React.FC = () => {
 	const [forecastLevels, setForecastLevels] = useState<string[]>([])
 	const [startFrame, setStartFrame] = useState(0)
 	const [imageInfo, setImageInfo] = useState({ width: 500, height: 500 })
+	const [frameValidTimes, setFrameValidTimes] = useState<number[]>([])
+	const [frameReadoutData, setFrameReadoutData] = useState<any>(null)
+	const [isLoadingReadoutData, setIsLoadingReadoutData] = useState(false)
+	const frameDataTimeoutRef = useRef<any>(null)
 
 	const getData = useCallback(async () => {
 		console.log('ForecastCompareHeightAnimator: Fetching data', modelId, runId, sectorId, productId, validTimeId)
@@ -64,6 +69,7 @@ const ForecastCompareHeightAnimator: React.FC = () => {
 		setImageInfo(data.imageInfo)
 		setForecastData(data.frames)
 		setForecastRuns(runs.runs)
+		setFrameValidTimes(data.validtimes || [])
 	}, [runId, modelId, sectorId, levelId, productId, validTimeId, setForecastData, setForecastRuns, router])
 
 	useEffect(() => {
@@ -95,6 +101,50 @@ const ForecastCompareHeightAnimator: React.FC = () => {
 		router.push(currentURL.join('/'))
 	}
 
+	// Request readout data for the current frame (level) at the selected valid time
+	const handleReadoutDataRequest = useCallback(
+		(frameIndex: number) => {
+			// Clear any existing timeout
+			if (frameDataTimeoutRef.current) {
+				clearTimeout(frameDataTimeoutRef.current)
+				frameDataTimeoutRef.current = null
+			}
+
+			// Reset state
+			setFrameReadoutData(null)
+
+			// Only fetch if we have all required parameters
+			if (!(modelId && runId && sectorId && productId)) {
+				console.log('Missing required parameters for readout data')
+				return
+			}
+
+			// Determine level from frame index and validtime index from route param
+			const levelForFrame = forecastLevels?.[frameIndex]
+			if (!levelForFrame) {
+				console.warn('No level found for frame index', frameIndex)
+				return
+			}
+			const vt = Number(validTimeId)
+			const validtimeIndex = frameValidTimes?.length ? Math.max(0, frameValidTimes.indexOf(vt)) : 0
+
+			setIsLoadingReadoutData(true)
+			frameDataTimeoutRef.current = setTimeout(async () => {
+				try {
+					const data = await getFrameReadoutData(modelId, runId, sectorId, levelForFrame, productId, validtimeIndex)
+					const readoutDataObj = { dataTypes: data.dataTypes, readoutData: data.readoutData }
+					setFrameReadoutData(readoutDataObj)
+				} catch (error) {
+					console.error('Error fetching frame readout data (compare-height):', error)
+				} finally {
+					setIsLoadingReadoutData(false)
+					frameDataTimeoutRef.current = null
+				}
+			}, 1000)
+		},
+		[modelId, runId, sectorId, productId, forecastLevels, frameValidTimes, validTimeId],
+	)
+
 	return (
 		<>
 			<div className={styles.forecastAnimatorContainer}>
@@ -107,6 +157,10 @@ const ForecastCompareHeightAnimator: React.FC = () => {
 						runsPerRow={runsPerRow}
 						activeRun={runId as string}
 						setActiveRun={handleRunChange}
+						enableReadouts={true}
+						frameReadoutData={frameReadoutData}
+						isLoadingReadoutData={isLoadingReadoutData}
+						requestReadoutData={handleReadoutDataRequest}
 						imageInfo={imageInfo}
 						initialZoomState={forecastZoomState}
 						setZoomState={setForecastZoomState}


### PR DESCRIPTION
Task: Add data readouts to the Height Comparison Animator for Forecast Models (Monday ID: 10084633364)

Summary of changes:
- Wire readouts in ForecastCompareHeightAnimator to mirror main ForecastAnimator.
- Added state for frame readout data and loading flag.
- Implemented handleReadoutDataRequest to fetch readout data using getFrameReadoutData with the selected level and the current compare valid time.
- Pass enableReadouts, frameReadoutData, isLoadingReadoutData, requestReadoutData props to Animator so DataTooltip displays values.
- Preserve existing run/level handling and image info; added validtimes from compare height endpoint for mapping.

Behavior:
- Readouts update when scrubbing/playing frames (levels) and when the compare valid time in the route changes.
- If the endpoint is missing or delayed, the tooltip shows a loading indicator or empty state, matching the main viewer’s UX.

Notes:
- Endpoint parity: get-compare-height returns `levels` and `validtimes`. We map the Animator’s frame index to a level, and map the current compare valid time to a validtime index to query readouts.
- No package changes required.

Testing:
- Navigate to compare-height pages and verify tooltip readouts appear after a short delay when pausing on a frame. Compare against main ForecastAnimator for consistency.

Please review.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author