### PR TITLE
Enable Forecast Sounding Feature for Forecast Model Comparison Page

### DIFF
--- a/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
@@ -9,7 +9,7 @@ import { useRootStore } from '@/store/useRootStore'
 import { getCompareModelsData } from '@/util/dataCalls/forecast/query-comparisons'
 import { getLatLonFromXYandSector } from '@/util/forecast/common-functions'
 import { useParams, useRouter } from 'next/navigation'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import ForecastCompareModelsAnimatorSettings from '../../_animatorSettingPanels/ForecastCompareModelsAnimatorSettings/ForecastCompareModelsAnimatorSettings'
 import styles from './ForecastCompareModelsAnimator.module.scss'
 
@@ -54,7 +54,8 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 
 	const soundingsSupported = useMemo(() => {
 		if (!currentActiveModel) return false
-		return FORECAST_MODELS[currentActiveModel]?.allowForecastSounding === true
+		const modelConfig = FORECAST_MODELS[currentActiveModel]
+		return modelConfig?.allowForecastSounding === true
 	}, [currentActiveModel])
 
 	// Handle frame updates to track current active model
@@ -65,9 +66,10 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 	}, [validTimeId, setForecastFrameValidTime])
 
 	// Sounding clickthrough handler
-	const onSoundingsClickthrough = useCallback(({ xPercent, yPercent }: { xPercent: number; yPercent: number }) => {
+	const onSoundingsClickthrough = useCallback((event: { xPercent: number; yPercent: number }) => {
 		if (!currentActiveModel || !soundingsSupported) return
 
+		const { xPercent, yPercent } = event
 		const locationId = getLatLonFromXYandSector(xPercent, yPercent, sectorId as string)
 		const baseParams = `/weather-data/forecast-models/${runId}/${currentActiveModel}/${sectorId}/${levelId}/${productId}`
 		const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
@@ -126,11 +128,7 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 						soundingsPicker={true}
 						soundingsPickerMode={forecastSoundingsPickMode && soundingsSupported}
 						soundingsPickerDisabled={!soundingsSupported}
-						setSoundingsPickerMode={(mode: boolean) => {
-							// Only allow enabling if current model supports soundings
-							if (mode && !soundingsSupported) return
-							setForecastSoundingsPickMode(mode)
-						}}
+						setSoundingsPickerMode={setForecastSoundingsPickMode}
 						onSoundingsClickthrough={onSoundingsClickthrough}
 						settingsComponent={
 							<AnimatorSettings title="Settings">

--- a/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
@@ -83,11 +83,6 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 		router.push(route)
 	}, [currentActiveModel, soundingsSupported, sectorId, runId, levelId, productId, validTimeId, router])
 
-	// Readout state (mirrors ForecastCompareHeightAnimator behavior)
-	const [frameReadoutData, setFrameReadoutData] = useState<any>(null)
-	const [isLoadingReadoutData, setIsLoadingReadoutData] = useState<boolean>(false)
-	const frameDataTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-
 	const getData = useCallback(async () => {
 		console.log('ForecastCompareModelsAnimator: Fetching data', runId, sectorId, levelId, productId, validTimeId, runFlag)
 		const data = await getCompareModelsData(runId, sectorId, levelId, productId, validTimeId, runFlag)
@@ -181,7 +176,11 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 						soundingsPicker={true}
 						soundingsPickerMode={forecastSoundingsPickMode && soundingsSupported}
 						soundingsPickerDisabled={!soundingsSupported}
-						setSoundingsPickerMode={setForecastSoundingsPickMode}
+						setSoundingsPickerMode={(mode: boolean) => {
+							// Only allow enabling if current model supports soundings
+							if (mode && !soundingsSupported) return
+							setForecastSoundingsPickMode(mode)
+						}}
 						onSoundingsClickthrough={onSoundingsClickthrough}
 						enableReadouts={true}
 						frameReadoutData={frameReadoutData}

--- a/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
@@ -65,7 +65,7 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 	}, [validTimeId, setForecastFrameValidTime])
 
 	// Sounding clickthrough handler
-	const onSoundingsClickthrough = useCallback(({ xPercent, yPercent }) => {
+	const onSoundingsClickthrough = useCallback(({ xPercent, yPercent }: { xPercent: number; yPercent: number }) => {
 		if (!currentActiveModel || !soundingsSupported) return
 
 		const locationId = getLatLonFromXYandSector(xPercent, yPercent, sectorId as string)
@@ -81,7 +81,7 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 
 		console.log('ForecastCompareModelsAnimator: Data fetched', data)
 
-		const initialFrame = data.models.indexOf(modelId as string) || 0
+		const initialFrame = Math.max(0, data.models.indexOf(modelId as string))
 		setStartFrame(initialFrame)
 		setCurrentFrame(initialFrame)
 		setForecastModels(data.models || [])

--- a/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
@@ -3,16 +3,19 @@
 import { Animator } from '@/components/elements/Animator/Animator'
 import AnimatorSettings from '@/components/elements/AnimatorSettings/AnimatorSettings'
 import MobileIconNav from '@/components/layout/MobileIconNav/MobileIconNav'
+import { FORECAST_MODELS } from '@/data/forecast/models'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useRootStore } from '@/store/useRootStore'
 import { getCompareModelsData } from '@/util/dataCalls/forecast/query-comparisons'
-import { useParams } from 'next/navigation'
-import React, { useCallback, useEffect, useState } from 'react'
+import { getLatLonFromXYandSector } from '@/util/forecast/common-functions'
+import { useParams, useRouter } from 'next/navigation'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ForecastCompareModelsAnimatorSettings from '../../_animatorSettingPanels/ForecastCompareModelsAnimatorSettings/ForecastCompareModelsAnimatorSettings'
 import styles from './ForecastCompareModelsAnimator.module.scss'
 
 const ForecastCompareModelsAnimator: React.FC = () => {
 	const { isMobile } = useIsMobile()
+	const router = useRouter()
 	const {
 		fcstModel: modelId,
 		fcstRun: runId,
@@ -31,10 +34,46 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 	const forecastLastFrameDwell = useRootStore.use.forecastLastFrameDwell()
 	const forecastLastFrameDwellTime = useRootStore.use.forecastLastFrameDwellTime()
 	const runFlag = useRootStore.use.runFlag()
+
+	// Sounding picker state
+	const forecastSoundingsPickMode = useRootStore.use.forecastSoundingsPickMode()
+	const setForecastSoundingsPickMode = useRootStore.use.setForecastSoundingsPickMode()
+	const setForecastFrameValidTime = useRootStore.use.setForecastFrameValidTime()
+
 	const [forecastData, setForecastData] = useState([])
 	const [forecastModels, setForecastModels] = useState<string[]>([])
 	const [startFrame, setStartFrame] = useState(0)
 	const [imageInfo, setImageInfo] = useState({ width: 800, height: 600 })
+	const [currentFrame, setCurrentFrame] = useState(0)
+
+	// Determine if the current active model supports soundings
+	const currentActiveModel = useMemo(() => {
+		if (!forecastModels.length || currentFrame >= forecastModels.length) return null
+		return forecastModels[currentFrame]
+	}, [forecastModels, currentFrame])
+
+	const soundingsSupported = useMemo(() => {
+		if (!currentActiveModel) return false
+		return FORECAST_MODELS[currentActiveModel]?.allowForecastSounding === true
+	}, [currentActiveModel])
+
+	// Handle frame updates to track current active model
+	const handleFrameUpdate = useCallback((frameIndex: number) => {
+		setCurrentFrame(frameIndex)
+		// Update the frame valid time for sounding picker
+		setForecastFrameValidTime(parseInt(validTimeId as string))
+	}, [validTimeId, setForecastFrameValidTime])
+
+	// Sounding clickthrough handler
+	const onSoundingsClickthrough = useCallback(({ xPercent, yPercent }) => {
+		if (!currentActiveModel || !soundingsSupported) return
+
+		const locationId = getLatLonFromXYandSector(xPercent, yPercent, sectorId as string)
+		const baseParams = `/weather-data/forecast-models/${runId}/${currentActiveModel}/${sectorId}/${levelId}/${productId}`
+		const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
+		const route = `${baseParams}${soundingParams}`
+		router.push(route)
+	}, [currentActiveModel, soundingsSupported, sectorId, runId, levelId, productId, validTimeId, router])
 
 	const getData = useCallback(async () => {
 		console.log('ForecastCompareModelsAnimator: Fetching data', runId, sectorId, levelId, productId, validTimeId, runFlag)
@@ -42,7 +81,9 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 
 		console.log('ForecastCompareModelsAnimator: Data fetched', data)
 
-		setStartFrame(data.models.indexOf(modelId as string) || 0)
+		const initialFrame = data.models.indexOf(modelId as string) || 0
+		setStartFrame(initialFrame)
+		setCurrentFrame(initialFrame)
 		setForecastModels(data.models || [])
 		setImageInfo(data.imageInfo)
 		setForecastData(data.frames)
@@ -55,6 +96,13 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 	useEffect(() => {
 		setForecastZoomFill(isMobile)
 	}, [isMobile, setForecastZoomFill])
+
+	// Update sounding picker mode based on current model support
+	useEffect(() => {
+		if (!soundingsSupported && forecastSoundingsPickMode) {
+			setForecastSoundingsPickMode(false)
+		}
+	}, [soundingsSupported, forecastSoundingsPickMode, setForecastSoundingsPickMode])
 
 	return (
 		<>
@@ -74,6 +122,16 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 						interval={1000 / forecastFrameRate}
 						lastFrameDwell={forecastLastFrameDwell}
 						lastFrameDwellTime={forecastLastFrameDwellTime * 1000}
+						onFrameUpdate={handleFrameUpdate}
+						soundingsPicker={true}
+						soundingsPickerMode={forecastSoundingsPickMode && soundingsSupported}
+						soundingsPickerDisabled={!soundingsSupported}
+						setSoundingsPickerMode={(mode: boolean) => {
+							// Only allow enabling if current model supports soundings
+							if (mode && !soundingsSupported) return
+							setForecastSoundingsPickMode(mode)
+						}}
+						onSoundingsClickthrough={onSoundingsClickthrough}
 						settingsComponent={
 							<AnimatorSettings title="Settings">
 								<ForecastCompareModelsAnimatorSettings />

--- a/src/components/elements/Animator/Animator.stories.tsx
+++ b/src/components/elements/Animator/Animator.stories.tsx
@@ -127,7 +127,7 @@ soundingPickerEnabled.args = {
 	soundingsPicker: true,
 	soundingsPickerMode: false,
 	soundingsPickerDisabled: false,
-	onSoundingsClickthrough: ({ xPercent, yPercent }) => {
+	onSoundingsClickthrough: ({ xPercent, yPercent }: { xPercent: number; yPercent: number }) => {
 		console.log('Sounding clicked at:', { xPercent, yPercent })
 	},
 }
@@ -140,7 +140,7 @@ soundingPickerDisabled.args = {
 	soundingsPicker: true,
 	soundingsPickerMode: false,
 	soundingsPickerDisabled: true,
-	onSoundingsClickthrough: ({ xPercent, yPercent }) => {
+	onSoundingsClickthrough: ({ xPercent, yPercent }: { xPercent: number; yPercent: number }) => {
 		console.log('Sounding clicked at:', { xPercent, yPercent })
 	},
 }
@@ -154,7 +154,7 @@ soundingPickerModelComparison.args = {
 	soundingsPicker: true,
 	soundingsPickerMode: false,
 	soundingsPickerDisabled: false, // This would be dynamically controlled in real implementation
-	onSoundingsClickthrough: ({ xPercent, yPercent }) => {
+	onSoundingsClickthrough: ({ xPercent, yPercent }: { xPercent: number; yPercent: number }) => {
 		console.log('Sounding clicked at:', { xPercent, yPercent })
 	},
 	onFrameUpdate: (frameIndex) => {

--- a/src/components/elements/Animator/Animator.stories.tsx
+++ b/src/components/elements/Animator/Animator.stories.tsx
@@ -118,3 +118,50 @@ withActiveFrameLabel.args = {
 	displayAllLabels: false,
 	scrubberFrameLoadStates: new Array(testDataFrameLabels2.frames.length).fill(true),
 }
+
+export const soundingPickerEnabled: StoryFn<typeof Animator> = TemplateFactory()
+soundingPickerEnabled.args = {
+	interval: 0.25,
+	frames: testFrames8x6,
+	imageInfo: { width: 800, height: 600 },
+	soundingsPicker: true,
+	soundingsPickerMode: false,
+	soundingsPickerDisabled: false,
+	onSoundingsClickthrough: ({ xPercent, yPercent }) => {
+		console.log('Sounding clicked at:', { xPercent, yPercent })
+	},
+}
+
+export const soundingPickerDisabled: StoryFn<typeof Animator> = TemplateFactory()
+soundingPickerDisabled.args = {
+	interval: 0.25,
+	frames: testFrames8x6,
+	imageInfo: { width: 800, height: 600 },
+	soundingsPicker: true,
+	soundingsPickerMode: false,
+	soundingsPickerDisabled: true,
+	onSoundingsClickthrough: ({ xPercent, yPercent }) => {
+		console.log('Sounding clicked at:', { xPercent, yPercent })
+	},
+}
+
+export const soundingPickerModelComparison: StoryFn<typeof Animator> = TemplateFactory()
+soundingPickerModelComparison.args = {
+	interval: 0.25,
+	frames: testFrames8x6,
+	imageInfo: { width: 800, height: 600 },
+	frameLabels: ['RAP', 'NAM', 'ECMWF', 'GFS', 'HRRR', 'RDPS'], // Mix of supported and unsupported models
+	soundingsPicker: true,
+	soundingsPickerMode: false,
+	soundingsPickerDisabled: false, // This would be dynamically controlled in real implementation
+	onSoundingsClickthrough: ({ xPercent, yPercent }) => {
+		console.log('Sounding clicked at:', { xPercent, yPercent })
+	},
+	onFrameUpdate: (frameIndex) => {
+		// In real implementation, this would check if the current model supports soundings
+		const supportedModels = ['RAP', 'NAM', 'GFS', 'HRRR']
+		const currentModel = ['RAP', 'NAM', 'ECMWF', 'GFS', 'HRRR', 'RDPS'][frameIndex]
+		const isSupported = supportedModels.includes(currentModel)
+		console.log(`Frame ${frameIndex}: ${currentModel} - Soundings ${isSupported ? 'supported' : 'not supported'}`)
+	},
+}

--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -40,7 +40,7 @@ interface IAnimatorProps {
 	soundingsPickerMode?: boolean
 	soundingsPickerDisabled?: boolean
 	setSoundingsPickerMode?: (mode: boolean) => void
-	onSoundingsClickthrough?: (event: any) => void
+	onSoundingsClickthrough?: (event: { xPercent: number; yPercent: number }) => void
 	// Scrubber enhancements
 	scrubberPlaceholderImageUrl?: string
 	scrubberFrameLoadStates?: boolean[]
@@ -97,7 +97,7 @@ export const Animator = ({
 	setSoundingsPickerMode = (mode: boolean) => {
 		console.warn('setSoundingsPickerMode function not provided, soundings picker mode will not be updated.', mode)
 	},
-	onSoundingsClickthrough = (event: any) => {
+	onSoundingsClickthrough = (event: { xPercent: number; yPercent: number }) => {
 		console.warn('onSoundingsClickthrough function not provided, soundings click-through will not be handled.', event)
 	},
 	scrubberPlaceholderImageUrl,

--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -38,6 +38,7 @@ interface IAnimatorProps {
 	setFullScreen?: (fullScreen: boolean) => void
 	soundingsPicker?: boolean
 	soundingsPickerMode?: boolean
+	soundingsPickerDisabled?: boolean
 	setSoundingsPickerMode?: (mode: boolean) => void
 	onSoundingsClickthrough?: (event: any) => void
 	// Scrubber enhancements
@@ -92,6 +93,7 @@ export const Animator = ({
 	fullScreen = false,
 	soundingsPicker = false,
 	soundingsPickerMode = false,
+	soundingsPickerDisabled = false,
 	setSoundingsPickerMode = (mode: boolean) => {
 		console.warn('setSoundingsPickerMode function not provided, soundings picker mode will not be updated.', mode)
 	},
@@ -167,6 +169,7 @@ export const Animator = ({
 				setFullScreen,
 				soundingsPicker,
 				soundingsPickerMode,
+				soundingsPickerDisabled,
 				setSoundingsPickerMode,
 				onSoundingsClickthrough,
 				scrubberPlaceholderImageUrl,

--- a/src/components/elements/Animator/ImageControls/ImageControls.module.scss
+++ b/src/components/elements/Animator/ImageControls/ImageControls.module.scss
@@ -23,6 +23,18 @@
     &:hover {
       color: var(--color-white);
     }
+    &.disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      &:hover {
+        color: var(--color-grey5);
+      }
+      svg {
+        * {
+          fill: var(--color-grey8) !important;
+        }
+      }
+    }
     svg {
       * {
         fill: var(--color-grey5);

--- a/src/components/elements/Animator/ImageControls/ImageControls.tsx
+++ b/src/components/elements/Animator/ImageControls/ImageControls.tsx
@@ -27,6 +27,7 @@ const ImageControls = ({ zoomIn, zoomOut, resetTransform }) => {
 		soundingsPickerMode,
 		setSoundingsPickerMode,
 		soundingsPicker,
+		soundingsPickerDisabled,
 	} = useAnimator()
 	const [overlayPanelOpen, setOverlayPanelOpen] = useState(false)
 	const expandToggle = () => {
@@ -67,8 +68,13 @@ const ImageControls = ({ zoomIn, zoomOut, resetTransform }) => {
 				<FontAwesomeIcon icon={fullScreen ? faDownLeftAndUpRightToCenter : faUpRightAndDownLeftFromCenter} />
 			</button>
 			{soundingsPicker && (
-				<button onClick={() => setSoundingsPickerMode(!soundingsPickerMode)}>
-					<WeatherBalloonIcon className={soundingsPickerMode ? styles.active : ''} />
+				<button
+					onClick={() => !soundingsPickerDisabled && setSoundingsPickerMode(!soundingsPickerMode)}
+					className={soundingsPickerDisabled ? styles.disabled : ''}
+					disabled={soundingsPickerDisabled}
+					title={soundingsPickerDisabled ? 'Soundings not supported for current model' : 'Toggle sounding picker'}
+				>
+					<WeatherBalloonIcon className={soundingsPickerMode && !soundingsPickerDisabled ? styles.active : ''} />
 				</button>
 			)}
 		</div>


### PR DESCRIPTION
## Description

This PR enables the forecast sounding feature for the Forecast Model Comparison page, allowing users to access soundings when viewing supported models (RAP, NAM, NAMNST, GFS, and HRRR).

## Changes Made

### Core Functionality
- **Added sounding picker to ForecastCompareModelsAnimator**: Integrated the sounding picker functionality similar to the main forecast models page
- **Dynamic enable/disable logic**: The sounding picker automatically enables/disables based on the currently active model in the animator
- **Model support detection**: Uses the `allowForecastSounding` property from `models.ts` to determine which models support soundings
- **Proper routing**: When enabled, clicking on the map correctly routes to the sounding page with all relevant parameters (run, model, sector, level, product, validtime)

### UI Enhancements
- **Added `soundingsPickerDisabled` prop**: New prop for the Animator component to control the disabled state
- **Updated ImageControls**: Enhanced the sounding picker button to show a disabled state with appropriate styling and tooltip
- **CSS improvements**: Added disabled styles for the sounding picker button with reduced opacity and "not-allowed" cursor

### Developer Experience
- **New Storybook stories**: Created three new stories demonstrating:
  - Sounding picker enabled state
  - Sounding picker disabled state  
  - Model comparison scenario with mixed supported/unsupported models

## Technical Implementation

### State Management
- Tracks the current active frame/model using `currentFrame` state
- Uses `useMemo` to efficiently determine if the current model supports soundings
- Automatically disables sounding picker mode when switching to unsupported models

### Supported Models
Based on `models.ts`, the following models support soundings:
- RAP (`allowForecastSounding: true`)
- NAM (`allowForecastSounding: true`)
- NAMNST (`allowForecastSounding: true`)
- GFS (`allowForecastSounding: true`)
- HRRR (`allowForecastSounding: true`)

### User Experience
- **Seamless integration**: The sounding picker appears and behaves identically to the main forecast models page
- **Visual feedback**: Users can clearly see when soundings are available vs. unavailable
- **Intuitive interaction**: Disabled state prevents accidental clicks and provides helpful tooltips

## Testing

### Manual Testing Scenarios
1. **Navigate to model comparison page** with mixed supported/unsupported models
2. **Verify sounding picker appears** in the image controls
3. **Switch between models** and confirm picker enables/disables appropriately
4. **Click sounding picker** when enabled and verify it routes correctly
5. **Hover over disabled picker** and verify tooltip appears

### Storybook Testing
- Run `npm run storybook` and navigate to the new Animator stories
- Test the three new sounding picker scenarios
- Verify enabled/disabled states render correctly

## Acceptance Criteria ✅

- [x] Forecast sounding picker is available on the Forecast Model Comparison page
- [x] Picker is enabled only when the active model is one of RAP, NAM, NAMNST, or GFS (+ HRRR)
- [x] When the active frame corresponds to an unsupported model, the picker displays a disabled state
- [x] New enabled/disabled behavior is implemented for the picker, tied to the active frame
- [x] New Storybook stories demonstrate the enabled/disabled toggle
- [x] Routing to the sounding page correctly passes all relevant parameters
- [x] Sounding feature behavior is consistent with the main forecast models page
- [x] Verified that models.ts is used as the source of truth for supported models

## Related

- Monday ID: 18007060984
- Feature branch follows naming convention: `feature/NXL-18007060984-TaskName`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author