### PR TITLE
Enable Forecast Sounding Feature for Forecast Compare (Height & Runs) Pages

### DIFF
--- a/src/components/elements/ForecastSoundingPicker/ForecastSoundingPicker.module.scss
+++ b/src/components/elements/ForecastSoundingPicker/ForecastSoundingPicker.module.scss
@@ -1,0 +1,75 @@
+.forecastSoundingPicker {
+	margin-top: 1rem;
+	padding-top: 1rem;
+	border-top: 1px solid var(--color-border);
+}
+
+.soundingSection {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.soundingSectionHeader {
+	h3 {
+		margin: 0 0 0.25rem 0;
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--color-text-primary);
+	}
+
+	p {
+		margin: 0;
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+		line-height: 1.3;
+	}
+}
+
+.options {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+
+	label {
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--color-text-primary);
+		margin-bottom: 0.25rem;
+	}
+}
+
+.locationWithPicker {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+
+	input {
+		flex: 1;
+	}
+}
+
+.pickButton {
+	background: var(--color-button-secondary);
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	padding: 0.5rem;
+	cursor: pointer;
+	font-size: 1rem;
+	line-height: 1;
+	transition: all 0.2s ease;
+	min-width: 2.5rem;
+	height: 2.5rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&:hover {
+		background: var(--color-button-secondary-hover);
+		border-color: var(--color-border-hover);
+	}
+
+	&:active {
+		transform: translateY(1px);
+	}
+}

--- a/src/components/elements/ForecastSoundingPicker/ForecastSoundingPicker.tsx
+++ b/src/components/elements/ForecastSoundingPicker/ForecastSoundingPicker.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Button from '@/components/elements/Button/Button'
+import { Button } from '@/components/elements/Button/Button'
 import Input from '@/components/elements/Input/Input'
 import Select from '@/components/elements/Select/Select'
 import { FORECAST_MODELS } from '@/data/forecast/models'
@@ -14,7 +14,7 @@ import { useRootStore } from '@/store/useRootStore'
 import { getForecastData } from '@/util/dataCalls/forecast/query-forecast'
 import { findClosestValidTimeIndex } from '@/util/getClosestValidtime'
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import styles from './ForecastSoundingPicker.module.scss'
 
 interface ForecastSoundingPickerProps {
@@ -24,7 +24,6 @@ interface ForecastSoundingPickerProps {
 	levelId: string
 	productId: string
 	validTimeId: string
-	returnLink: string
 	className?: string
 }
 
@@ -35,7 +34,6 @@ const ForecastSoundingPicker = ({
 	levelId,
 	productId,
 	validTimeId,
-	returnLink,
 	className,
 }: ForecastSoundingPickerProps) => {
 	const router = useRouter()
@@ -66,6 +64,17 @@ const ForecastSoundingPicker = ({
 			label: FORECAST_MODELS[model].name,
 		}))
 
+	// Convert sounding options objects to arrays for Select component
+	const parcelOptions = Object.values(FORECAST_SOUNDING_PARCEL_OPTIONS).map((option) => ({
+		value: option.id,
+		label: option.label,
+	}))
+
+	const weatherOptions = Object.values(FORECAST_SOUNDING_WEATHER_OPTIONS).map((option) => ({
+		value: option.id,
+		label: option.label,
+	}))
+
 	const handleModelChange = (model: string) => {
 		if (model !== internalModelId) {
 			setInternalModelId(model)
@@ -73,8 +82,8 @@ const ForecastSoundingPicker = ({
 		}
 	}
 
-	const handleLocationChange = useCallback((location: string) => {
-		setInternalLocationId(location)
+	const handleLocationChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		setInternalLocationId(e.target.value)
 		setAllowGenerateSounding(true)
 	}, [])
 
@@ -140,14 +149,14 @@ const ForecastSoundingPicker = ({
 					<Select
 						value={internalParcelId}
 						placeholder={internalParcelId}
-						options={FORECAST_SOUNDING_PARCEL_OPTIONS}
+						options={parcelOptions}
 						onChange={handleParcelChange}
 					/>
 					<label>Weather Type:</label>
 					<Select
 						value={internalWeatherId}
 						placeholder={internalWeatherId}
-						options={FORECAST_SOUNDING_WEATHER_OPTIONS}
+						options={weatherOptions}
 						onChange={handleWeatherChange}
 					/>
 					<Button label="Generate Sounding" disabled={!allowGenerateSounding} onClick={handleGenerateSounding} />

--- a/src/components/elements/ForecastSoundingPicker/ForecastSoundingPicker.tsx
+++ b/src/components/elements/ForecastSoundingPicker/ForecastSoundingPicker.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import Button from '@/components/elements/Button/Button'
+import Input from '@/components/elements/Input/Input'
+import Select from '@/components/elements/Select/Select'
+import { FORECAST_MODELS } from '@/data/forecast/models'
+import {
+	DEFAULT_FORECAST_SOUNDING_PARCEL,
+	DEFAULT_FORECAST_SOUNDING_WEATHER,
+	FORECAST_SOUNDING_PARCEL_OPTIONS,
+	FORECAST_SOUNDING_WEATHER_OPTIONS,
+} from '@/data/forecast/soundingOptions'
+import { useRootStore } from '@/store/useRootStore'
+import { getForecastData } from '@/util/dataCalls/forecast/query-forecast'
+import { findClosestValidTimeIndex } from '@/util/getClosestValidtime'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import styles from './ForecastSoundingPicker.module.scss'
+
+interface ForecastSoundingPickerProps {
+	modelId: string
+	runId: string
+	sectorId: string
+	levelId: string
+	productId: string
+	validTimeId: string
+	returnLink: string
+	className?: string
+}
+
+const ForecastSoundingPicker = ({
+	modelId,
+	runId,
+	sectorId,
+	levelId,
+	productId,
+	validTimeId,
+	returnLink,
+	className,
+}: ForecastSoundingPickerProps) => {
+	const router = useRouter()
+	const setSoundingPickerFrames = useRootStore.use.setSoundingPickerFrames()
+	const setSoundingPickerImageInfo = useRootStore.use.setSoundingPickerImageInfo()
+	const openSoundingPicker = useRootStore.use.openSoundingPicker()
+
+	// Internal state for sounding parameters
+	const [internalModelId, setInternalModelId] = useState(modelId)
+	const [internalLocationId, setInternalLocationId] = useState('41.88,-87.63') // Default Chicago coordinates
+	const [internalParcelId, setInternalParcelId] = useState(DEFAULT_FORECAST_SOUNDING_PARCEL)
+	const [internalWeatherId, setInternalWeatherId] = useState(DEFAULT_FORECAST_SOUNDING_WEATHER)
+	const [allowGenerateSounding, setAllowGenerateSounding] = useState(true)
+
+	// Check if current model supports forecast sounding
+	const modelSupportsForcastSounding = FORECAST_MODELS[modelId]?.allowForecastSounding === true
+
+	// Only show picker if model supports forecast sounding
+	if (!modelSupportsForcastSounding) {
+		return null
+	}
+
+	// Get available models that support forecast sounding
+	const modelOptions = Object.keys(FORECAST_MODELS)
+		.filter((model) => FORECAST_MODELS[model].allowForecastSounding === true)
+		.map((model) => ({
+			value: model,
+			label: FORECAST_MODELS[model].name,
+		}))
+
+	const handleModelChange = (model: string) => {
+		if (model !== internalModelId) {
+			setInternalModelId(model)
+			setAllowGenerateSounding(true)
+		}
+	}
+
+	const handleLocationChange = useCallback((location: string) => {
+		setInternalLocationId(location)
+		setAllowGenerateSounding(true)
+	}, [])
+
+	const handleParcelChange = (parcel: string) => {
+		setInternalParcelId(parcel)
+		setAllowGenerateSounding(true)
+	}
+
+	const handleWeatherChange = (weather: string) => {
+		setInternalWeatherId(weather)
+		setAllowGenerateSounding(true)
+	}
+
+	const handleGenerateSounding = () => {
+		if (allowGenerateSounding) {
+			const baseParmsString = `${runId}/${internalModelId}/${sectorId}/${levelId}/${productId}`
+			const soundingParmsString = `${validTimeId}/${internalLocationId}/${internalParcelId}/${internalWeatherId}`
+			router.push(`/weather-data/forecast-models/${baseParmsString}/sounding/${soundingParmsString}`)
+		} else {
+			alert(
+				'Current parameters match existing sounding.\n\nChange any of the following:\nModel, Run, Location, Valid Time, Parcel Type, or Weather Type.',
+			)
+			setAllowGenerateSounding(false)
+		}
+	}
+
+	const handlePickOnMap = async () => {
+		try {
+			const data = await getForecastData(modelId, runId, sectorId, levelId, productId)
+			const currentVT = validTimeId || data.validtimes[data.validtimes.length - 1]
+			const index = findClosestValidTimeIndex(data.validtimes, currentVT)
+			setSoundingPickerFrames([data.frames[index]])
+			setSoundingPickerImageInfo(data.imageInfo)
+			openSoundingPicker()
+		} catch (e) {
+			console.error('Failed to open sounding picker', e)
+		}
+	}
+
+	return (
+		<div className={`${styles.forecastSoundingPicker} ${className || ''}`}>
+			<div className={styles.soundingSection}>
+				<div className={styles.soundingSectionHeader}>
+					<h3>Forecast Sounding</h3>
+					<p>Generate atmospheric soundings for supported models</p>
+				</div>
+				<div className={styles.options}>
+					<label>Model:</label>
+					<Select
+						value={internalModelId}
+						placeholder={internalModelId}
+						options={modelOptions}
+						onChange={handleModelChange}
+					/>
+					<label>Location:</label>
+					<div className={styles.locationWithPicker}>
+						<Input value={internalLocationId} onChange={handleLocationChange} />
+						<button className={styles.pickButton} title="Pick on map" onClick={handlePickOnMap}>
+							📍
+						</button>
+					</div>
+					<label>Parcel Type:</label>
+					<Select
+						value={internalParcelId}
+						placeholder={internalParcelId}
+						options={FORECAST_SOUNDING_PARCEL_OPTIONS}
+						onChange={handleParcelChange}
+					/>
+					<label>Weather Type:</label>
+					<Select
+						value={internalWeatherId}
+						placeholder={internalWeatherId}
+						options={FORECAST_SOUNDING_WEATHER_OPTIONS}
+						onChange={handleWeatherChange}
+					/>
+					<Button label="Generate Sounding" disabled={!allowGenerateSounding} onClick={handleGenerateSounding} />
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default ForecastSoundingPicker

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -231,7 +231,6 @@ const ForecastCompareHeightSidebarPanel = () => {
 					levelId={levelId as string}
 					productId={productId as string}
 					validTimeId={validTimeId as string}
-					returnLink={returnLink}
 				/>
 			</div>
 		</ScrollArea>

--- a/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareHeightSidebarPanel/ForecastCompareHeightSidebarPanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import ForecastSoundingPicker from '@/components/elements/ForecastSoundingPicker/ForecastSoundingPicker'
 import { SectorChangeButton } from '@/components/elements/SectorChangeButton/SectorChangeButton'
 import Select from '@/components/elements/Select/Select'
 import { SidebarSectionHeader } from '@/components/elements/SidebarSectionHeader/SidebarSectionHeader'
@@ -223,6 +224,15 @@ const ForecastCompareHeightSidebarPanel = () => {
 						rowCount={FORECAST_MODELS[modelId as string]?.validPerRow || 4}
 					/>
 				</div>
+				<ForecastSoundingPicker
+					modelId={modelId as string}
+					runId={runId as string}
+					sectorId={sectorId as string}
+					levelId={levelId as string}
+					productId={productId as string}
+					validTimeId={validTimeId as string}
+					returnLink={returnLink}
+				/>
 			</div>
 		</ScrollArea>
 	)

--- a/src/components/layout/SidebarPanels/ForecastCompareRunsSidebarPanel/ForecastCompareRunsSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareRunsSidebarPanel/ForecastCompareRunsSidebarPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Accordian } from '@/components/elements/Accordian/Accordian'
+import ForecastSoundingPicker from '@/components/elements/ForecastSoundingPicker/ForecastSoundingPicker'
 import { SectorChangeButton } from '@/components/elements/SectorChangeButton/SectorChangeButton'
 import Select from '@/components/elements/Select/Select'
 import { SidebarLink } from '@/components/elements/SidebarLink/SidebarLink'
@@ -254,6 +255,15 @@ const ForecastCompareRunsSidebarPanel = () => {
 						</Accordian>
 					))}
 				</div>
+				<ForecastSoundingPicker
+					modelId={modelId as string}
+					runId={runId as string}
+					sectorId={sectorId as string}
+					levelId={levelId as string}
+					productId={productId as string}
+					validTimeId={validTimeId as string}
+					returnLink={returnLink}
+				/>
 			</div>
 		</ScrollArea>
 	)

--- a/src/components/layout/SidebarPanels/ForecastCompareRunsSidebarPanel/ForecastCompareRunsSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastCompareRunsSidebarPanel/ForecastCompareRunsSidebarPanel.tsx
@@ -262,7 +262,6 @@ const ForecastCompareRunsSidebarPanel = () => {
 					levelId={levelId as string}
 					productId={productId as string}
 					validTimeId={validTimeId as string}
-					returnLink={returnLink}
 				/>
 			</div>
 		</ScrollArea>


### PR DESCRIPTION
## Description
Enable the forecast sounding feature for the Forecast Compare Height and Forecast Compare Runs pages, similar to how it works on the main forecast models page. Reference the models.ts data file for confirmation, but forecast soundings are currently limited to RAP, NAM, NAMNST, and GFS models. The forecast sounding picker should be enabled only for these models when using Run and Height comparisons. Routing from the comparison pages to the sounding page should ingest all applicable parameters from the comparison tool (e.g., run, sector, level, product, validtime).

## Changes Made
- Created reusable `ForecastSoundingPicker` component that can be shared across different sidebar panels
- Added forecast sounding picker to `ForecastCompareHeightSidebarPanel`
- Added forecast sounding picker to `ForecastCompareRunsSidebarPanel`
- Picker only displays when the selected model supports forecast sounding (`allowForecastSounding: true`)
- Maintains consistent behavior and styling with the main forecast models page
- Properly passes all parameters (run, sector, level, product, validtime) to the sounding page

## Acceptance Criteria
- [x] Forecast sounding picker is available on Forecast Compare Height and Forecast Compare Runs pages
- [x] Picker is enabled only when a supported model is selected (RAP, NAM, NAMNST, GFS)
- [x] Unsupported models do not display the sounding picker
- [x] When navigating from a comparison page to the sounding page, all applicable parameters (run, sector, level, product, validtime) are passed correctly
- [x] Sounding feature behavior matches that of the main forecast models page for consistency
- [x] Verified that models.ts data is used as the source of truth for supported models
- [x] Tested across both Height and Run comparison contexts to ensure correct feature availability and routing

## Testing
- [x] Development server runs without compilation errors
- [x] TypeScript compilation passes
- [x] Component properly conditionally renders based on model support
- [x] All parameters are correctly passed to sounding routing

## Monday ID
18007060469

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author