### PR TITLE
MInor Satellite Updates

### DIFF
--- a/src/components/layout/SidebarPanels/SatRadSidebarPanel/SatradSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/SatRadSidebarPanel/SatradSidebarPanel.tsx
@@ -31,11 +31,37 @@ const SatradSidebarPanel = () => {
 	const openSlideoutPanel = useRootStore.use.openSlideoutPanel()
 
 	useEffect(() => {
-		if (!SATRAD_PRODUCTS[productId as string] || !SATRAD_SCALE_REGIONS[regionId as string] || !ALL_SATRAD_SECTORS[sectorId as string]) {
+		const currentRegionId = regionId as string
+		const currentSectorId = sectorId as string
+		const currentProductId = productId as string
+
+		// 1. Region sanitization
+		const sanitizedRegionId = SATRAD_SCALE_REGIONS[currentRegionId] ? currentRegionId : DEFAULT_SATRAD_REGION
+
+		// 2. Sector sanitization (must belong to sanitizedRegionId's sectors list)
+		const regionSectors = SATRAD_SCALE_REGIONS[sanitizedRegionId].sectors
+		const sanitizedSectorId = regionSectors.includes(currentSectorId)
+			? currentSectorId
+			: regionSectors.includes(DEFAULT_SATRAD_SECTOR)
+				? DEFAULT_SATRAD_SECTOR
+				: regionSectors[0]
+
+		// 3. Product sanitization (must exist inside the sanitized sector's product set)
+		const sectorProductsObj = ALL_SATRAD_SECTORS[sanitizedSectorId]?.products || {}
+		const sanitizedProductId = sectorProductsObj[currentProductId]
+			? currentProductId
+			: sectorProductsObj[DEFAULT_SATRAD_PRODUCT]
+				? DEFAULT_SATRAD_PRODUCT
+				: Object.keys(sectorProductsObj).sort((a, b) => parseInt(a, 10) - parseInt(b, 10))[0]
+
+		// 4. If any param changed, push sanitized route
+		if (currentRegionId !== sanitizedRegionId || currentSectorId !== sanitizedSectorId || currentProductId !== sanitizedProductId) {
 			resetSatradZoomState()
-			router.push(`/weather-data/satellite-mosaic-radar/${DEFAULT_SATRAD_PRODUCT}/${DEFAULT_SATRAD_REGION}/${DEFAULT_SATRAD_SECTOR}`)
-		} else if (tempRegionIdRef.current !== regionId) {
-			tempRegionIdRef.current = regionId as string
+			router.push(`/weather-data/satellite-mosaic-radar/${sanitizedProductId}/${sanitizedRegionId}/${sanitizedSectorId}`)
+			tempRegionIdRef.current = sanitizedRegionId
+		} else if (tempRegionIdRef.current !== sanitizedRegionId) {
+			// Keep tempRegionIdRef synced for sector selector logic
+			tempRegionIdRef.current = sanitizedRegionId
 		}
 	}, [productId, regionId, sectorId, router, resetSatradZoomState])
 

--- a/src/data/satrad/sectorsLocal.ts
+++ b/src/data/satrad/sectorsLocal.ts
@@ -115,6 +115,9 @@ const SATRAD_SECTOR_LOCAL_WISCONSIN_ID = 'Wisconsin'
 const SATRAD_SECTOR_LOCAL_WYOMING_ID = 'Wyoming'
 const SATRAD_SECTOR_LOCAL_YELLOWSTONE_ID = 'Yellowstone'
 const SATRAD_SECTOR_LOCAL_CA_ST_JOHNS_ID = 'ca_stjohns'
+const SATRAD_SECTOR_LOCAL_OTTAWA_ID = 'Ottawa'
+const SATRAD_SECTOR_LOCAL_PENNSYLVANIA_ID = 'Pennsylvania'
+const SATRAD_SECTOR_LOCAL_PANHANDLE_ID = 'Panhandle'
 
 export const SATRAD_SECTORS_LOCAL_NAMER = {
 	[SATRAD_SECTOR_LOCAL_ALABAMA_ID]: {
@@ -1142,6 +1145,33 @@ export const SATRAD_SECTORS_LOCAL_NAMER = {
 		coordinates: [
 			[-57.05, 45.8],
 			[-48.5, 48.5],
+		],
+		products: SATRAD_PRODUCTS,
+	},
+	[SATRAD_SECTOR_LOCAL_OTTAWA_ID]: {
+		name: 'Ottawa',
+		type: 'Geobox',
+		coordinates: [
+			[-81.8, 44.1],
+			[-71.9, 47.0],
+		],
+		products: SATRAD_PRODUCTS,
+	},
+	[SATRAD_SECTOR_LOCAL_PENNSYLVANIA_ID]: {
+		name: 'Pennsylvania',
+		type: 'Geobox',
+		coordinates: [
+			[-81.9, 39.5],
+			[-72.3, 42.3],
+		],
+		products: SATRAD_PRODUCTS,
+	},
+	[SATRAD_SECTOR_LOCAL_PANHANDLE_ID]: {
+		name: 'TX/OK Panhandle',
+		type: 'Geobox',
+		coordinates: [
+			[-105.3, 33.5],
+			[-96.3, 37.6],
 		],
 		products: SATRAD_PRODUCTS,
 	},

--- a/src/data/satrad/sectorsRegional.ts
+++ b/src/data/satrad/sectorsRegional.ts
@@ -1,4 +1,11 @@
-import { SATRAD_PRODUCTS } from './products'
+import { SATRAD_PRODUCTS, SATRAD_PRODUCT_ABI_11_ID, SATRAD_PRODUCT_ABI_12_ID, SATRAD_PRODUCT_ABI_14_ID, SATRAD_PRODUCT_ABI_16_ID } from './products'
+
+// Filtered product set for sectors needing omission of specific ABI bands
+const SATRAD_PRODUCTS_NO_ABI_11_12_14_16 = Object.fromEntries(
+	Object.entries(SATRAD_PRODUCTS).filter(
+		([key]) => ![SATRAD_PRODUCT_ABI_11_ID, SATRAD_PRODUCT_ABI_12_ID, SATRAD_PRODUCT_ABI_14_ID, SATRAD_PRODUCT_ABI_16_ID].includes(key),
+	),
+)
 
 // Regional Sectors
 const SATRAD_SECTOR_REGIONAL_BERING_SEA_ID = 'BeringSea'
@@ -191,7 +198,7 @@ export const SATRAD_SECTORS_REGIONAL_NAMER = {
 			[-76.25, 9.5],
 			[-59.5, 25.0],
 		],
-		products: SATRAD_PRODUCTS,
+		products: SATRAD_PRODUCTS_NO_ABI_11_12_14_16,
 	},
 	[SATRAD_SECTOR_REGIONAL_SOUTH_CENTRAL_ID]: {
 		name: 'South Central US',

--- a/src/data/satrad/sectorsSubregional.ts
+++ b/src/data/satrad/sectorsSubregional.ts
@@ -1,4 +1,11 @@
-import { SATRAD_PRODUCTS } from './products'
+import { SATRAD_PRODUCTS, SATRAD_PRODUCT_ABI_11_ID, SATRAD_PRODUCT_ABI_12_ID, SATRAD_PRODUCT_ABI_14_ID, SATRAD_PRODUCT_ABI_16_ID } from './products'
+
+// Puerto Rico region subset: omit ABI 11,12,14,16 (thermal bands not provided in this data region)
+const SATRAD_PRODUCTS_PUERTO = Object.fromEntries(
+	Object.entries(SATRAD_PRODUCTS).filter(
+		([key]) => ![SATRAD_PRODUCT_ABI_11_ID, SATRAD_PRODUCT_ABI_12_ID, SATRAD_PRODUCT_ABI_14_ID, SATRAD_PRODUCT_ABI_16_ID].includes(key),
+	),
+)
 
 // Sub-regional Sectors
 const SATRAD_SECTOR_SUBREGIONAL_BAHAMAS_ID = 'Bahamas_sub'
@@ -198,7 +205,7 @@ export const SATRAD_SECTORS_SUBREGIONAL_NAMER = {
 			[-75.1, 15.25],
 			[-58.75, 24.25],
 		],
-		products: SATRAD_PRODUCTS,
+		products: SATRAD_PRODUCTS_PUERTO,
 	},
 	[SATRAD_SECTOR_SUBREGIONAL_E_CARIBBEAN_ID]: {
 		name: 'Eastern Caribbean',
@@ -207,7 +214,7 @@ export const SATRAD_SECTORS_SUBREGIONAL_NAMER = {
 			[-74.25, 11.0],
 			[-58.25, 17.9],
 		],
-		products: SATRAD_PRODUCTS,
+		products: SATRAD_PRODUCTS_PUERTO,
 	},
 	[SATRAD_SECTOR_SUBREGIONAL_E_GULF_COAST_ID]: {
 		name: 'East Gulf Coast',


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 18047261981

## Description
See Monday task updates; links to reports in discord. Some sectors were missing from local north america. some products are not available for sectors that come from a special puerto rico dataset. Because now, not all sectors have all products, it is possible to switch to a sector that does not have the previously loaded product, so I added new default/sanitation steps for relevant params in the satrad sidebar panel following the mold of similar steps taken in forecast sidebar panels.

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run dev`

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
