### PR TITLE
Update Forecast Sounding Page Return Link for Contextual Routing

### DIFF
--- a/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.tsx
@@ -98,6 +98,11 @@ const ForecastAnimator: React.FC = () => {
 		const route = `${baseParams}${soundingParams}`
 		// console.log('  🔗 Full route:', route)
 
+		// Store current page as referrer for the sounding page
+		if (typeof window !== 'undefined') {
+			sessionStorage.setItem('forecastSoundingReferrer', window.location.pathname)
+		}
+
 		router.push(route)
 		setForecastSoundingsPickMode(false) // Deactivate soundings picker mode after navigation
 	}

--- a/src/components/blocks/_animators/ForecastCompareHeightAnimator/ForecastCompareHeightAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareHeightAnimator/ForecastCompareHeightAnimator.tsx
@@ -121,6 +121,12 @@ const ForecastCompareHeightAnimator: React.FC = () => {
 		const baseParams = `/weather-data/forecast-models/${runId}/${modelId}/${sectorId}/${levelId}/${productId}`
 		const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
 		const route = `${baseParams}${soundingParams}`
+
+		// Store current page as referrer for the sounding page
+		if (typeof window !== 'undefined') {
+			sessionStorage.setItem('forecastSoundingReferrer', window.location.pathname)
+		}
+
 		router.push(route)
 	}, [soundingsSupported, sectorId, runId, modelId, levelId, productId, validTimeId, router])
 

--- a/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
@@ -86,6 +86,12 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 			const baseParams = `/weather-data/forecast-models/${runId}/${currentActiveModel}/${sectorId}/${levelId}/${productId}`
 			const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
 			const route = `${baseParams}${soundingParams}`
+
+			// Store current page as referrer for the sounding page
+			if (typeof window !== 'undefined') {
+				sessionStorage.setItem('forecastSoundingReferrer', window.location.pathname)
+			}
+
 			router.push(route)
 		},
 		[currentActiveModel, soundingsSupported, sectorId, runId, levelId, productId, validTimeId, router],

--- a/src/components/blocks/_animators/ForecastCompareRunsAnimator/ForecastCompareRunsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareRunsAnimator/ForecastCompareRunsAnimator.tsx
@@ -121,6 +121,12 @@ const ForecastCompareRunsAnimator: React.FC = () => {
 			const baseParams = `/weather-data/forecast-models/${currentActiveRun}/${modelId}/${sectorId}/${levelId}/${productId}`
 			const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
 			const route = `${baseParams}${soundingParams}`
+
+			// Store current page as referrer for the sounding page
+			if (typeof window !== 'undefined') {
+				sessionStorage.setItem('forecastSoundingReferrer', window.location.pathname)
+			}
+
 			router.push(route)
 		},
 		[soundingsSupported, currentActiveRun, sectorId, modelId, levelId, productId, validTimeId, router],

--- a/src/components/layout/SidebarPanels/ForecastSoundingSidebarPanel/ForecastSoundingsSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastSoundingSidebarPanel/ForecastSoundingsSidebarPanel.tsx
@@ -25,6 +25,44 @@ import { SOUNDING_TEXT_SLIDEOUT } from '@/data/vars'
 import ScrollArea from '../../ScrollArea/ScrollArea'
 import styles from './ForecastSoundingsSidebarPanel.module.scss'
 
+// Utility function to determine return link and text based on referring page
+const getReturnLinkInfo = (runId: string | string[], modelId: string | string[], sectorId: string | string[], levelId: string | string[], productId: string | string[], validTimeId: string | string[]) => {
+	// Ensure all parameters are strings
+	const runIdStr = Array.isArray(runId) ? runId[0] : runId
+	const modelIdStr = Array.isArray(modelId) ? modelId[0] : modelId
+	const sectorIdStr = Array.isArray(sectorId) ? sectorId[0] : sectorId
+	const levelIdStr = Array.isArray(levelId) ? levelId[0] : levelId
+	const productIdStr = Array.isArray(productId) ? productId[0] : productId
+	const validTimeIdStr = Array.isArray(validTimeId) ? validTimeId[0] : validTimeId
+	// Check if we have a referrer stored in sessionStorage
+	const referrer = typeof window !== 'undefined' ? sessionStorage.getItem('forecastSoundingReferrer') : null
+
+	if (referrer) {
+		if (referrer.includes('/compare-height/')) {
+			return {
+				url: `/weather-data/forecast-models/${runIdStr}/${modelIdStr}/${sectorIdStr}/${levelIdStr}/${productIdStr}/compare-height/${validTimeIdStr}`,
+				text: 'Return to Height Comparison'
+			}
+		} else if (referrer.includes('/compare-runs/')) {
+			return {
+				url: `/weather-data/forecast-models/${runIdStr}/${modelIdStr}/${sectorIdStr}/${levelIdStr}/${productIdStr}/compare-runs/${validTimeIdStr}`,
+				text: 'Return to Runs Comparison'
+			}
+		} else if (referrer.includes('/compare-models/')) {
+			return {
+				url: `/weather-data/forecast-models/${runIdStr}/${modelIdStr}/${sectorIdStr}/${levelIdStr}/${productIdStr}/compare-models/${validTimeIdStr}`,
+				text: 'Return to Models Comparison'
+			}
+		}
+	}
+
+	// Default fallback to regular forecast animator
+	return {
+		url: `/weather-data/forecast-models/${runIdStr}/${modelIdStr}/${sectorIdStr}/${levelIdStr}/${productIdStr}`,
+		text: 'Return to Forecast Models'
+	}
+}
+
 const ForecastSoundingsSidebarPanel = () => {
 	const {
 		fcstModel: modelId,
@@ -56,8 +94,20 @@ const ForecastSoundingsSidebarPanel = () => {
 
 	const [allowGenerateSounding, setAllowGenerateSounding] = useState(false)
 	const [returnLink, setReturnLink] = useState('')
+	const [returnText, setReturnText] = useState('Return to Forecast Models')
 	const forecastSoundingRunId = useRootStore.use.forecastSoundingRunId() // this version from the store helps to keep the sidebar in sync with the animator
 	const forecastSoundingValidTime = useRootStore.use.forecastFrameValidTime()
+
+	// Store referrer information when component mounts
+	useEffect(() => {
+		if (typeof window !== 'undefined' && document.referrer) {
+			const referrerUrl = new URL(document.referrer)
+			// Only store if it's from the same origin and contains forecast-models
+			if (referrerUrl.origin === window.location.origin && referrerUrl.pathname.includes('/weather-data/forecast-models/')) {
+				sessionStorage.setItem('forecastSoundingReferrer', referrerUrl.pathname)
+			}
+		}
+	}, [])
 
 	const sanitizeCollectAndSetData = useCallback(async () => {
 		const sanitizedModelId = !FORECAST_MODELS[modelId as string] ? DEFAULT_FORECAST_MODEL : modelId
@@ -124,8 +174,20 @@ const ForecastSoundingsSidebarPanel = () => {
 		setInternalParcelId(sanitizedParcelId)
 		setInternalWeatherId(sanitizedWeatherId)
 		setAllowGenerateSounding(false) // Reset the generate button state
-		setReturnLink(`/weather-data/forecast-models/${runId}/${sanitizedModelId}/${sanitizedSectorId}/${sanitizedLevelId}/${sanitizedProductId}`)
-	}, [modelId, runId, sectorId, levelId, productId, validTimeId, locationId, parcelId, weatherId, isStationId, router])
+
+		// Update return link and text based on referring page and current validtime
+		const currentValidTime = forecastSoundingValidTime || validTimeId
+		const returnLinkInfo = getReturnLinkInfo(
+			forecastSoundingRunId || runId,
+			sanitizedModelId,
+			sanitizedSectorId,
+			sanitizedLevelId,
+			sanitizedProductId,
+			currentValidTime
+		)
+		setReturnLink(returnLinkInfo.url)
+		setReturnText(returnLinkInfo.text)
+	}, [modelId, runId, sectorId, levelId, productId, validTimeId, locationId, parcelId, weatherId, isStationId, router, forecastSoundingRunId, forecastSoundingValidTime])
 
 	useEffect(() => {
 		sanitizeCollectAndSetData()
@@ -198,7 +260,7 @@ const ForecastSoundingsSidebarPanel = () => {
 	return (
 		<ScrollArea>
 			<div className={styles.ForecastSoundingsSidebarPanel}>
-				<SidebarSectionHeader name="Return to Forecast Models" linkUrl={returnLink} />
+				<SidebarSectionHeader name={returnText} linkUrl={returnLink} />
 				<div className={styles.options}>
 					<label>Model:</label>
 					<Select


### PR DESCRIPTION
## Description

This PR implements contextual routing for the Forecast Sounding page return link. The return link now correctly identifies which animator/page the user came from and routes them back to the appropriate page with updated parameters.

## Changes Made

### Core Functionality
- **Dynamic Return Link Detection**: Added utility function `getReturnLinkInfo()` to determine the correct return URL and text based on the referring page
- **Session Storage Integration**: Store referrer information when navigating to sounding page from any animator
- **Parameter Preservation**: Updated parameters (runId, modelId, validtimeId) are preserved when routing back
- **Contextual Text**: Return link text changes based on originating page (e.g., 'Return to Height Comparison')

### Updated Components

#### ForecastSoundingsSidebarPanel
- Added dynamic return link and text state management
- Implemented referrer detection using sessionStorage
- Updated return link generation to include current validtime from sounding page
- Maintained backward compatibility with existing behavior

#### Animator Components
- **ForecastAnimator**: Store referrer when navigating to sounding
- **ForecastCompareHeightAnimator**: Store referrer when navigating to sounding
- **ForecastCompareRunsAnimator**: Store referrer when navigating to sounding
- **ForecastCompareModelsAnimator**: Store referrer when navigating to sounding

## Routing Behavior

| Originating Page | Return Link | Return Text |
|------------------|-------------|-------------|
| ForecastAnimator | `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}` | Return to Forecast Models |
| Compare Height | `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}/compare-height/{validtime}` | Return to Height Comparison |
| Compare Runs | `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}/compare-runs/{validtime}` | Return to Runs Comparison |
| Compare Models | `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}/compare-models/{validtime}` | Return to Models Comparison |

## Technical Details

- Uses `sessionStorage` to persist referrer information across page navigation
- Handles TypeScript parameter types correctly (string | string[])
- Preserves updated validtime from the sounding page when returning
- Falls back to default behavior if no referrer is detected
- Only stores referrer for same-origin forecast-models URLs for security

## Testing

✅ Development server runs without errors
✅ TypeScript compilation passes
✅ All four animator types correctly store referrer information
✅ Return link dynamically updates based on originating page
✅ Updated parameters are preserved when routing back

## Acceptance Criteria Met

- [x] Return link correctly identifies originating animator/page
- [x] ForecastAnimator behavior remains unchanged
- [x] Compare Height routes to `/compare-height/{validtime}` with updated parameters
- [x] Compare Runs routes to `/compare-runs/{validtime}` with updated parameters
- [x] Compare Models routes to `/compare-models/{validtime}` with updated parameters
- [x] {validtime} reflects current/updated validtime from Forecast Sounding page
- [x] Updated parameters (runId, modelId, validtimeId) are preserved
- [x] Non-updated parameters (sectorId, levelId, productId) are not modified
- [x] Same component used for back button with dynamic URL and text

Closes Monday Item: NXL-18045727019

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author