### PR TITLE
feat: Implement contextual routing for Forecast Sounding page return link

### DIFF
--- a/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastAnimator/ForecastAnimator.tsx
@@ -95,7 +95,7 @@ const ForecastAnimator: React.FC = () => {
 
 		const baseParams = `/weather-data/forecast-models/${runId}/${modelId}/${sectorId}/${levelId}/${productId}`
 		const soundingParams = `/sounding/${frameValidTimeRef.current}/${locationId}/ml/severe`
-		const route = `${baseParams}${soundingParams}`
+		const route = `${baseParams}${soundingParams}?source=forecast`
 		// console.log('  🔗 Full route:', route)
 
 		router.push(route)

--- a/src/components/blocks/_animators/ForecastCompareHeightAnimator/ForecastCompareHeightAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareHeightAnimator/ForecastCompareHeightAnimator.tsx
@@ -120,7 +120,7 @@ const ForecastCompareHeightAnimator: React.FC = () => {
 		const locationId = getLatLonFromXYandSector(xPercent, yPercent, sectorId as string)
 		const baseParams = `/weather-data/forecast-models/${runId}/${modelId}/${sectorId}/${levelId}/${productId}`
 		const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
-		const route = `${baseParams}${soundingParams}`
+		const route = `${baseParams}${soundingParams}?source=compare-height`
 		router.push(route)
 	}, [soundingsSupported, sectorId, runId, modelId, levelId, productId, validTimeId, router])
 

--- a/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareModelsAnimator/ForecastCompareModelsAnimator.tsx
@@ -85,7 +85,7 @@ const ForecastCompareModelsAnimator: React.FC = () => {
 			const locationId = getLatLonFromXYandSector(xPercent, yPercent, sectorId as string)
 			const baseParams = `/weather-data/forecast-models/${runId}/${currentActiveModel}/${sectorId}/${levelId}/${productId}`
 			const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
-			const route = `${baseParams}${soundingParams}`
+			const route = `${baseParams}${soundingParams}?source=compare-models`
 			router.push(route)
 		},
 		[currentActiveModel, soundingsSupported, sectorId, runId, levelId, productId, validTimeId, router],

--- a/src/components/blocks/_animators/ForecastCompareRunsAnimator/ForecastCompareRunsAnimator.tsx
+++ b/src/components/blocks/_animators/ForecastCompareRunsAnimator/ForecastCompareRunsAnimator.tsx
@@ -120,7 +120,7 @@ const ForecastCompareRunsAnimator: React.FC = () => {
 			const locationId = getLatLonFromXYandSector(xPercent, yPercent, sectorId as string)
 			const baseParams = `/weather-data/forecast-models/${currentActiveRun}/${modelId}/${sectorId}/${levelId}/${productId}`
 			const soundingParams = `/sounding/${validTimeId}/${locationId}/ml/severe`
-			const route = `${baseParams}${soundingParams}`
+			const route = `${baseParams}${soundingParams}?source=compare-runs`
 			router.push(route)
 		},
 		[soundingsSupported, currentActiveRun, sectorId, modelId, levelId, productId, validTimeId, router],

--- a/src/components/layout/SidebarPanels/ForecastSoundingSidebarPanel/ForecastSoundingsSidebarPanel.tsx
+++ b/src/components/layout/SidebarPanels/ForecastSoundingSidebarPanel/ForecastSoundingsSidebarPanel.tsx
@@ -18,7 +18,7 @@ import { useRootStore } from '@/store/useRootStore'
 import { getForecastData } from '@/util/dataCalls/forecast/query-forecast'
 import { buildProductsByLevel, fetchStationCoordinates } from '@/util/forecast/common-functions'
 import { findClosestValidTimeIndex } from '@/util/getClosestValidtime'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, usePathname, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
 import { SOUNDING_TEXT_SLIDEOUT } from '@/data/vars'
@@ -38,9 +38,22 @@ const ForecastSoundingsSidebarPanel = () => {
 		fcstSndWeather: weatherId,
 	} = useParams()
 	const router = useRouter()
+	const pathname = usePathname()
 	// sounding location prep
 	const locationId = tempLocId ? decodeURIComponent(tempLocId as string) : null // removes encoding from URL, specifically commas
 	const isStationId = locationId?.length === 4 && !locationId?.includes(',')
+
+	// Get source parameter from URL to determine originating animator
+	const [sourceAnimator, setSourceAnimator] = useState<string | null>(null)
+
+	useEffect(() => {
+		// Extract source parameter from current URL
+		if (typeof window !== 'undefined') {
+			const urlParams = new URLSearchParams(window.location.search)
+			const source = urlParams.get('source')
+			setSourceAnimator(source)
+		}
+	}, [pathname])
 
 	// menu prep
 	// these references are specifically to avoid unnecessary re-renders and wait for a button click to update the URL
@@ -58,6 +71,26 @@ const ForecastSoundingsSidebarPanel = () => {
 	const [returnLink, setReturnLink] = useState('')
 	const forecastSoundingRunId = useRootStore.use.forecastSoundingRunId() // this version from the store helps to keep the sidebar in sync with the animator
 	const forecastSoundingValidTime = useRootStore.use.forecastFrameValidTime()
+
+	// Function to generate contextual return link based on originating animator
+	const generateReturnLink = useCallback((baseRunId: string, baseModelId: string, baseSectorId: string, baseLevelId: string, baseProductId: string, currentValidTimeId: string) => {
+		const baseParams = `${baseRunId}/${baseModelId}/${baseSectorId}/${baseLevelId}/${baseProductId}`
+		const basePath = `/weather-data/forecast-models/${baseParams}`
+
+		// Determine which animator the user came from based on the source parameter
+		switch (sourceAnimator) {
+			case 'compare-height':
+				return `${basePath}/compare-height/${currentValidTimeId}`
+			case 'compare-runs':
+				return `${basePath}/compare-runs/${currentValidTimeId}`
+			case 'compare-models':
+				return `${basePath}/compare-models/${currentValidTimeId}`
+			case 'forecast':
+			default:
+				// Default case: return to standard forecast animator
+				return basePath
+		}
+	}, [sourceAnimator])
 
 	const sanitizeCollectAndSetData = useCallback(async () => {
 		const sanitizedModelId = !FORECAST_MODELS[modelId as string] ? DEFAULT_FORECAST_MODEL : modelId
@@ -124,8 +157,17 @@ const ForecastSoundingsSidebarPanel = () => {
 		setInternalParcelId(sanitizedParcelId)
 		setInternalWeatherId(sanitizedWeatherId)
 		setAllowGenerateSounding(false) // Reset the generate button state
-		setReturnLink(`/weather-data/forecast-models/${runId}/${sanitizedModelId}/${sanitizedSectorId}/${sanitizedLevelId}/${sanitizedProductId}`)
-	}, [modelId, runId, sectorId, levelId, productId, validTimeId, locationId, parcelId, weatherId, isStationId, router])
+
+		// Generate contextual return link based on originating animator
+		const runIdString: string = Array.isArray(runId) ? runId[0] : (runId || '')
+		const validTimeIdString: string = Array.isArray(validTimeId) ? validTimeId[0] : (validTimeId || '')
+		const sanitizedModelIdString: string = Array.isArray(sanitizedModelId) ? sanitizedModelId[0] : (sanitizedModelId || '')
+		const sanitizedSectorIdString: string = Array.isArray(sanitizedSectorId) ? sanitizedSectorId[0] : (sanitizedSectorId || '')
+		const sanitizedLevelIdString: string = Array.isArray(sanitizedLevelId) ? sanitizedLevelId[0] : (sanitizedLevelId || '')
+		const sanitizedProductIdString: string = Array.isArray(sanitizedProductId) ? sanitizedProductId[0] : (sanitizedProductId || '')
+		const contextualReturnLink = generateReturnLink(runIdString, sanitizedModelIdString, sanitizedSectorIdString, sanitizedLevelIdString, sanitizedProductIdString, validTimeIdString)
+		setReturnLink(contextualReturnLink)
+	}, [modelId, runId, sectorId, levelId, productId, validTimeId, locationId, parcelId, weatherId, isStationId, router, generateReturnLink])
 
 	useEffect(() => {
 		sanitizeCollectAndSetData()

--- a/src/components/layout/SoundingPickerPanel/SoundingPickerPanel.tsx
+++ b/src/components/layout/SoundingPickerPanel/SoundingPickerPanel.tsx
@@ -87,7 +87,18 @@ const SoundingPickerPanel = () => {
 		const effectiveValidTime = storeValidTime || validTimeId
 		const baseParmsString = `${effectiveRunId}/${modelId}/${sectorId}/${levelId}/${productId}`
 		const soundingParmsString = `${effectiveValidTime}/${locationId}/${parcelId}/${weatherId}`
-		const fullRoute = `/weather-data/forecast-models/${baseParmsString}/sounding/${soundingParmsString}`
+
+		// Determine source parameter based on current pathname
+		let sourceParam = 'forecast' // default
+		if (pathname.includes('/compare-height/')) {
+			sourceParam = 'compare-height'
+		} else if (pathname.includes('/compare-runs/')) {
+			sourceParam = 'compare-runs'
+		} else if (pathname.includes('/compare-models/')) {
+			sourceParam = 'compare-models'
+		}
+
+		const fullRoute = `/weather-data/forecast-models/${baseParmsString}/sounding/${soundingParmsString}?source=${sourceParam}`
 
 		// console.log('  🔗 Full route:', fullRoute)
 		router.push(fullRoute)


### PR DESCRIPTION
## Overview

Implements contextual routing for the Forecast Sounding page return link to improve user experience by routing users back to the correct originating animator page.

## Changes Made

### Core Implementation
- **Added source parameter tracking**: Each animator now includes a `source` query parameter when navigating to sounding pages
- **Updated ForecastSoundingsSidebarPanel**: Added logic to detect originating animator and generate appropriate return links
- **Modified all forecast animators**: Updated sounding clickthrough handlers to include source identification

### Specific Updates
- **ForecastAnimator**: Adds `?source=forecast` to sounding URLs
- **ForecastCompareHeightAnimator**: Adds `?source=compare-height` to sounding URLs  
- **ForecastCompareRunsAnimator**: Adds `?source=compare-runs` to sounding URLs
- **ForecastCompareModelsAnimator**: Adds `?source=compare-models` to sounding URLs
- **SoundingPickerPanel**: Detects current path context to add appropriate source parameter

### Return Link Behavior
- **From ForecastAnimator**: Returns to `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}`
- **From Compare Height**: Returns to `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}/compare-height/{validtime}`
- **From Compare Runs**: Returns to `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}/compare-runs/{validtime}`
- **From Compare Models**: Returns to `/weather-data/forecast-models/{runId}/{modelId}/{sectorId}/{levelId}/{productId}/compare-models/{validtime}`

## Technical Details

### Parameter Preservation
- Updated parameters (runId, modelId, validtimeId) are preserved when routing back
- Non-updated parameters (sectorId, levelId, productId) remain unchanged
- Current validtime value is used in return URLs (not literal text)

### Backward Compatibility
- Maintains compatibility with existing sounding navigation
- Defaults to forecast animator return link if source parameter is missing
- No breaking changes to existing functionality

## Testing

✅ **Build Status**: Successfully builds without errors  
✅ **TypeScript**: All type checks pass  
✅ **Development Server**: Runs without issues  

## Acceptance Criteria Met

- [x] Return link correctly identifies originating animator
- [x] ForecastAnimator behavior remains unchanged
- [x] Compare Height returns to `/compare-height/{validtime}` with updated parameters
- [x] Compare Runs returns to `/compare-runs/{validtime}` with updated parameters  
- [x] Compare Models returns to `/compare-models/{validtime}` with updated parameters
- [x] {validtime} reflects current/updated validtime value
- [x] Updated parameters (runId, modelId, validtimeId) are preserved
- [x] Non-updated parameters (sectorId, levelId, productId) are not modified

## Related

Resolves Monday ID: 18045727019

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author