### PR TITLE
Mobile Menu Login and Dashboard Access QOL

### DIFF
--- a/src/components/layout/MobileMenu/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu/MobileMenu.tsx
@@ -70,24 +70,22 @@ const MobileMenu = ({ children, navItems }) => {
 				>
 					<ScrollArea>
 						{children}
-						{menuId === null && (
-							<>
-								{session?.user?.email ? (
-									<div className={styles.authSection}>
-										<div className={styles.userInfo}>
-											<div className={styles.userAvatar}>{session.user.email.charAt(0).toUpperCase()}</div>
-											<div className={styles.userEmail}>{session.user.email}</div>
-										</div>
-										<button className={styles.logoutButton} onClick={() => signOut()}>
-											Logout
-										</button>
+						{session?.user?.email ? (
+							<div className={styles.authSection}>
+								<Link href="/dashboard/">
+									<div className={styles.userInfo}>
+										<div className={styles.userAvatar}>{session.user.email.charAt(0).toUpperCase()}</div>
+										<div className={styles.userEmail}>{session.user.email}</div>
 									</div>
-								) : (
-									<Link href="/login/">
-										<div className={styles.loginButton}>Login</div>
-									</Link>
-								)}
-							</>
+								</Link>
+								<button className={styles.logoutButton} onClick={() => signOut()}>
+									Logout
+								</button>
+							</div>
+						) : (
+							<Link href="/login/">
+								<div className={styles.loginButton}>Login</div>
+							</Link>
 						)}
 						{menuId !== null && ifMenuItemHasChildren(menuId) && (
 							<MobileMenuItem


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 18358902777

## Description
I noticed it's not really easy to get to the dashboard on mobile. The only way to get to it seemed to be to log out then back in so that you get routed to the dashboard. I made 2 small changes to help make this a little easier given the current placement in the menu. I made it so that once logged in, clicking the user info (avatar or email address) will navigate to the dashboard. I also made the login/logout menu item available on all sections of the mobile menu. This gives a mobile user the same access a desktop user has.

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run dev`

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):
<img width="467" height="835" alt="image" src="https://github.com/user-attachments/assets/9bb50a6c-a7f2-43dc-b3ce-1a6f2d2ad396" />

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
