### PR TITLE
Fix map animation, navigation, and initial zoom issues

### DIFF
--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -85,7 +85,7 @@ interface IAnimatorProvider extends IAnimatorProps {
 	mode: 'image' | 'map'
 	mapRegion: 'conus' | 'alaska' | 'hawaii' | 'namer'
 	mapZoomState: mapZoomState // Current map zoom state
-	setMapZoomState: (mapZoomState: mapZoomState) => void // Update map zoom state
+	setMapZoomState: (mapZoomState: mapZoomState, keepTarget?: boolean) => void // Update map zoom state
 	targetMapZoomState: mapZoomState | null // Target zoom state for smooth animation
 	mapLayerVisibility: Record<string, boolean> // Map layer visibility state
 	setMapLayerVisibility: (visibility: Record<string, boolean>) => void // Update map layer visibility
@@ -186,6 +186,14 @@ export const Animator = ({
 	// Use individual values as dependencies to avoid infinite loop from object reference changes
 	useEffect(() => {
 		if (initialMapZoomState) {
+			// Check if the new initial state is actually different from the CURRENT state
+			// If they are the same (or very close), it's likely just a sync from a manual pan,
+			// so we shouldn't set a target (which would lock the controller)
+			const isDifferentFromCurrent =
+				Math.abs(initialMapZoomState.zoom - mapZoomState.zoom) > 0.001 ||
+				Math.abs(initialMapZoomState.latitude - mapZoomState.latitude) > 0.001 ||
+				Math.abs(initialMapZoomState.longitude - mapZoomState.longitude) > 0.001
+
 			// Only update if the values actually changed to prevent infinite loop
 			const hasChanged =
 				!targetMapZoomState ||
@@ -193,11 +201,21 @@ export const Animator = ({
 				targetMapZoomState.latitude !== initialMapZoomState.latitude ||
 				targetMapZoomState.longitude !== initialMapZoomState.longitude
 
-			if (hasChanged) {
+			console.log('Animator Zoom Update:', {
+				initial: initialMapZoomState,
+				current: mapZoomState,
+				target: targetMapZoomState,
+				isDifferent: isDifferentFromCurrent,
+				hasChanged,
+			})
+
+			if (hasChanged && isDifferentFromCurrent) {
+				console.log('Setting target map zoom state:', initialMapZoomState)
 				setTargetMapZoomState(initialMapZoomState)
 			}
 		}
-	}, [initialMapZoomState, targetMapZoomState])
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [initialMapZoomState])
 
 	// Initialize layer visibility from layerConfig (required)
 	// If mapLayerVisibility prop is provided AND has keys, use it (controlled component)
@@ -305,11 +323,17 @@ export const Animator = ({
 				mode,
 				mapRegion,
 				mapZoomState,
-				setMapZoomState: (newMapZoomState: mapZoomState) => {
+				setMapZoomState: (newMapZoomState: mapZoomState, keepTarget = false) => {
 					setMapZoomStateLocal(newMapZoomState)
-					setMapZoomState(newMapZoomState)
-					// Clear target when user manually changes zoom
-					setTargetMapZoomState(null)
+					// Only notify parent if NOT keeping target (i.e. manual move or end of animation)
+					// This prevents the parent from syncing intermediate animation states back to us
+					if (!keepTarget) {
+						setMapZoomState(newMapZoomState)
+					}
+					// Clear target when user manually changes zoom, unless keepTarget is true
+					if (!keepTarget) {
+						setTargetMapZoomState(null)
+					}
 				},
 				targetMapZoomState,
 				mapLayerVisibility: mapLayerVisibilityLocal,

--- a/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
@@ -372,7 +372,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 		// Smooth zoom animation using custom easing
 		// Moves a small percentage of the distance each frame for smooth transitions
 		useEffect(() => {
-			if (!targetMapZoomState || !setMapZoomState) return
+			if (!targetMapZoomState || !setMapZoomState) return undefined
 
 			const EASING_FACTOR = 0.05 // Move 5% of distance each frame (slower = smaller value)
 			const THRESHOLD = 0.001 // Stop when delta is very small
@@ -407,7 +407,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 					zoom: currentZoom + deltaZoom * EASING_FACTOR,
 					latitude: currentLat + deltaLat * EASING_FACTOR,
 					longitude: currentLon + deltaLon * EASING_FACTOR,
-				})
+				}, true)
 			})
 
 			return () => cancelAnimationFrame(animationFrame)
@@ -1338,19 +1338,8 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 				const regionInfo = findRegionAtPoint(lat, lon, undefined, cwaZonesData)
 
 				if (regionInfo?.type === 'cwa' && regionInfo.wfoId) {
-					// Call the callback
+					// Call the callback to navigate (route drives the state)
 					onCwaClick(regionInfo.id, regionInfo.wfoId)
-
-					// Calculate zoom view state to focus on this CWA zone
-					if (containerRef.current && _onViewStateChange) {
-						const rect = containerRef.current.getBoundingClientRect()
-						const newViewState = zoomToCwaZone(cwaZonesData as any, regionInfo.id, rect.width, rect.height, 0.15)
-
-						if (newViewState) {
-							// Update the view state to zoom to the CWA region
-							_onViewStateChange(newViewState)
-						}
-					}
 				}
 			}
 		}
@@ -1408,13 +1397,17 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 						//transitionInterpolator: new FlyToInterpolator({ speed: 2 }),
 						//transitionDuration: 'auto',
 					}}
-					controller={{
-						scrollZoom: {
-							smooth: true,
-						},
-						// Keyboard controls
-						keyboard: true,
-					}}
+					controller={
+						targetMapZoomState
+							? false
+							: {
+									scrollZoom: {
+										smooth: true,
+									},
+									// Keyboard controls
+									keyboard: true,
+							  }
+					}
 					layers={layers}
 					onViewStateChange={handleViewStateChange}
 					onClick={handleDeckGLClick}

--- a/src/components/elements/Animator/AnimatorMapMachine/utils/mapZoomUtils.ts
+++ b/src/components/elements/Animator/AnimatorMapMachine/utils/mapZoomUtils.ts
@@ -17,7 +17,7 @@ export interface MapViewState {
  * Returns [minLon, minLat, maxLon, maxLat]
  */
 export function calculateBoundingBox(feature: Feature | FeatureCollection): [number, number, number, number] {
-	return bbox(feature)
+	return bbox(feature) as [number, number, number, number]
 }
 
 /**
@@ -111,7 +111,12 @@ export function findCwaFeature(cwaData: FeatureCollection, cwaId: string): Featu
 	const feature = cwaData.features.find((f) => {
 		const id = f.properties?.id || f.properties?.ID || f.properties?.CWA
 		const wfo = f.properties?.WFO || f.properties?.wfo
-		return id === cwaId || wfo === cwaId
+		const fullStaId = f.properties?.FULLSTAID || f.properties?.fullstaid
+		
+		const searchId = cwaId.toUpperCase()
+		return (id && id.toUpperCase() === searchId) || 
+		       (wfo && wfo.toUpperCase() === searchId) ||
+		       (fullStaId && fullStaId.toUpperCase() === searchId)
 	})
 
 	return feature || null

--- a/src/components/elements/WFOAnimator/WFOAnimator.tsx
+++ b/src/components/elements/WFOAnimator/WFOAnimator.tsx
@@ -3,7 +3,7 @@
 import { Animator } from '@/components/elements/Animator/Animator'
 import { MapFrame } from '@/components/elements/Animator/AnimatorMapMachine/types'
 import { zoomToCwaZone } from '@/components/elements/Animator/AnimatorMapMachine/utils/mapZoomUtils'
-import { mapZoomState } from '@/components/elements/Animator/types'
+import { mapZoomState } from '@/types/general'
 import cwaZonesData from '@/data/d3Map/cwaZones.json'
 import { createCountyAlertFrame } from '@/util/dataCalls/alerts/createCountyAlertFrames'
 import { fetchRealTimeHazards, parseHazardsToCountyMap } from '@/util/dataCalls/alerts/parseCountyAlerts'
@@ -22,7 +22,20 @@ export const WFOAnimator = ({ selectedWFOId, view = 'overview' }: WFOAnimatorPro
 	const [isLoading, setIsLoading] = useState(true)
 	const [error, setError] = useState<string | null>(null)
 	const [mapLayerVisibility, setMapLayerVisibility] = useState<Record<string, boolean>>({})
-	const [targetZoomStateRaw, setTargetZoomStateRaw] = useState<mapZoomState | undefined>(undefined)
+	const [targetZoomStateRaw, setTargetZoomStateRaw] = useState<mapZoomState | undefined>(() => {
+		if (view === 'detail' && selectedWFOId) {
+			const viewportWidth = 1200
+			const viewportHeight = 800
+			return zoomToCwaZone(cwaZonesData as any, selectedWFOId, viewportWidth, viewportHeight, 0.3) || undefined
+		} else if (view === 'overview') {
+			return {
+				zoom: 4,
+				latitude: 39.8283,
+				longitude: -98.5795,
+			}
+		}
+		return undefined
+	})
 
 	// Memoize targetZoomState to prevent infinite loop
 	// The object reference must remain stable unless the actual values change
@@ -43,12 +56,15 @@ export const WFOAnimator = ({ selectedWFOId, view = 'overview' }: WFOAnimatorPro
 
 	// Update target zoom state when view or selectedWFOId changes
 	useEffect(() => {
+		console.log('WFOAnimator Effect Triggered:', { view, selectedWFOId })
 		if (view === 'detail' && selectedWFOId) {
 			// Calculate zoom state for the selected WFO
 			// Use standard viewport dimensions for calculation
 			const viewportWidth = 1200
 			const viewportHeight = 800
-			const zoomState = zoomToCwaZone(cwaZonesData as any, selectedWFOId, viewportWidth, viewportHeight, 0.15)
+			const zoomState = zoomToCwaZone(cwaZonesData as any, selectedWFOId, viewportWidth, viewportHeight, 0.3)
+
+			console.log('Calculated Zoom State:', zoomState)
 
 			if (zoomState) {
 				setTargetZoomStateRaw({
@@ -161,7 +177,7 @@ export const WFOAnimator = ({ selectedWFOId, view = 'overview' }: WFOAnimatorPro
 				interval={500}
 				hideControls={view === 'detail'} // Hide controls in detail view (single frame, no animation needed)
 				mapLayerVisibility={mapLayerVisibility}
-				onMapLayerVisibilityChange={setMapLayerVisibility}
+				setMapLayerVisibility={setMapLayerVisibility}
 				onCwaClick={handleCwaClick} // Enable CWA clicks in both overview and detail view
 				selectedWFOId={view === 'detail' ? selectedWFOId : null} // Pass selected WFO for filtering
 				initialMapZoomState={targetZoomState}

--- a/src/components/layout/SidebarPanels/WFOPanel/WFOPanel.module.scss
+++ b/src/components/layout/SidebarPanels/WFOPanel/WFOPanel.module.scss
@@ -26,3 +26,27 @@
 	display: flex;
 	flex-direction: column;
 }
+
+.backToOverview {
+	padding: 10px 10px 0 10px;
+	display: flex;
+	justify-content: center;
+}
+
+.backButton {
+	background: none;
+	border: 1px solid var(--color-grey3);
+	color: var(--text-secondary);
+	padding: 6px 12px;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 0.8rem;
+	transition: all 0.2s ease;
+	width: 100%;
+
+	&:hover {
+		background-color: rgba(255, 255, 255, 0.05);
+		border-color: var(--text-secondary);
+		color: var(--text-primary);
+	}
+}

--- a/src/components/layout/SidebarPanels/WFOPanel/WFOPanel.tsx
+++ b/src/components/layout/SidebarPanels/WFOPanel/WFOPanel.tsx
@@ -155,12 +155,21 @@ const WFOPanel = ({ basepath }: WFOPanelProps) => {
 		}))
 	}, [wfoData])
 
-	// Determine back button URL based on whether an office is selected
-	const backButtonUrl = selectedOfficeId ? wfoBasePath : basepath
+	// Determine back button URL - always go back to landing page
+	const backButtonUrl = basepath
 
 	return (
 		<>
 			<SidebarSectionHeader name="NWS WFO" linkUrl={backButtonUrl} />
+			
+			{selectedOfficeId && (
+				<div className={styles.backToOverview}>
+					<button onClick={() => router.push(wfoBasePath)} className={styles.backButton}>
+						&larr; Back to Overview
+					</button>
+				</div>
+			)}
+
 			<div className={styles.selectTitle}>Available Forecast Offices:</div>
 			<div className={styles.wfoSelector}>
 				<SelectSearchable


### PR DESCRIPTION
## Monday.com Item

Monday Item ID: 18386649576

## Description

This PR fixes several issues related to the NWS WFO map animation, navigation, and initial state handling.

**Key Changes:**
-   **Fixed Map Animation:** Resolved infinite loops and "snapping" behavior in `Animator.tsx` and `AnimatorMapMachine.tsx` by correctly managing target zoom state and disabling interactions during transitions.
-   **Route-Driven State:** Refactored map interactions so that both map clicks and dropdown selections update the URL route. The map state now reacts to route changes, ensuring consistent behavior across all input methods.
-   **Fixed Initial Zoom:** Solved a bug where loading a WFO page directly (e.g., `.../KOUN`) would result in the map being zoomed out. Added lazy initialization to `WFOAnimator.tsx` to calculate the correct zoom state immediately on mount.
-   **Fixed WFO ID Matching:** Addressed a critical issue where 4-letter station IDs (e.g., "KOUN") in the URL were not matching the 3-letter CWA codes in the map data. Updated `mapZoomUtils.ts` to also check the `FULLSTAID` property.
-   **Navigation Updates:**
    -   The "NWS WFO" back button now consistently navigates to the landing page.
    -   Added a new "Back to Overview" button in the `WFOPanel` to easily clear the selection.
-   **Improved Visibility:** Increased the padding around WFO zones when zooming to ensure they aren't cut off.

## How Has This Been Tested?

Manually verified the following scenarios:
1.  **Dropdown Selection:** Selecting a WFO from the sidebar correctly zooms and centers the map.
2.  **Map Click:** Clicking a WFO zone on the map updates the URL and triggers the same smooth zoom animation.
3.  **Direct Load:** Reloading the page with a specific WFO URL (e.g., `/KOUN`) correctly initializes the map zoomed in on that region.
4.  **Navigation:** Verified that the "Back to Overview" and "NWS WFO" buttons function as expected.
5.  **Animation:** Confirmed that pan/zoom transitions are smooth and map interactions are temporarily disabled during the animation to prevent conflicts.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)