### PR TITLE
Feature/nxl 18386653444 county clickthrough

### DIFF
--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -71,6 +71,8 @@ export interface IAnimatorProps {
 	onStormClick?: (stormId: string) => void
 	// CWA zone click handler
 	onCwaClick?: (cwaId: string, wfoId: string) => void
+	// County click handler
+	onCountyClick?: (countyId: string, countyData: any) => void
 	// Selected WFO ID for filtering counties in detail view
 	selectedWFOId?: string | null
 }
@@ -91,6 +93,7 @@ interface IAnimatorProvider extends IAnimatorProps {
 	setMapLayerVisibility: (visibility: Record<string, boolean>) => void // Update map layer visibility
 	onStormClick?: (stormId: string) => void // Storm click handler
 	onCwaClick?: (cwaId: string, wfoId: string) => void // CWA zone click handler
+	onCountyClick?: (countyId: string, countyData: any) => void // County click handler
 	mapDataType: 'alerts' | 'hurricane' | 'all' // Type of data being displayed
 	layerConfig?: any // Layer configuration for filtering which layers are shown
 	selectedWFOId?: string | null // Selected WFO ID for filtering counties in detail view
@@ -173,6 +176,7 @@ export const Animator = ({
 	layerConfig,
 	onStormClick,
 	onCwaClick,
+	onCountyClick,
 	selectedWFOId,
 }: IAnimatorProps) => {
 	const [isPlaying, setIsPlaying] = useState(false)
@@ -345,6 +349,7 @@ export const Animator = ({
 				layerConfig,
 				onStormClick,
 				onCwaClick,
+				onCountyClick,
 				selectedWFOId,
 			}}
 		>

--- a/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
@@ -31,7 +31,6 @@ import { createStatesLayers } from './layers/StatesLayer'
 import { createStormTrackLayer } from './layers/StormTrackLayer'
 import { createWorldLayer } from './layers/WorldLayer'
 import { IAnimatorMapMachineProps, MapFrame } from './types'
-import { zoomToCwaZone } from './utils/mapZoomUtils'
 import { createAffectedRegionsGeoJSON, detectAllAffectedRegions, getWarningColor } from './utils/regionDetection'
 
 // Import booleanPointInPolygon for point-in-polygon detection
@@ -226,6 +225,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			layerVisibility = {},
 			onStormClick,
 			onCwaClick,
+			onCountyClick,
 			selectedWFOId,
 		},
 		ref,
@@ -404,11 +404,14 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 				}
 
 				// Move a fraction of the distance
-				setMapZoomState({
-					zoom: currentZoom + deltaZoom * EASING_FACTOR,
-					latitude: currentLat + deltaLat * EASING_FACTOR,
-					longitude: currentLon + deltaLon * EASING_FACTOR,
-				}, true)
+				setMapZoomState(
+					{
+						zoom: currentZoom + deltaZoom * EASING_FACTOR,
+						latitude: currentLat + deltaLat * EASING_FACTOR,
+						longitude: currentLon + deltaLon * EASING_FACTOR,
+					},
+					true,
+				)
 			})
 
 			return () => cancelAnimationFrame(animationFrame)
@@ -561,20 +564,20 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 				frame.data.features.forEach((feature: any) => {
 					const countyId = feature.properties?.id
 					const alerts = feature.properties?.alerts // Array of alert objects with color property
-					
+
 					if (countyId && Array.isArray(alerts) && alerts.length > 0 && countyToCwaMap.has(countyId)) {
 						const cwaId = countyToCwaMap.get(countyId)
 						if (cwaId) {
 							if (!cwaColorMap[cwaId]) {
 								cwaColorMap[cwaId] = new Set()
 							}
-							
+
 							// Add each alert's color to the CWA's set
 							alerts.forEach((alert: any) => {
 								if (alert.color && Array.isArray(alert.color)) {
 									// Check if it's the default grey [200, 200, 200, ...]
 									const isDefaultGrey = alert.color[0] === 200 && alert.color[1] === 200 && alert.color[2] === 200
-									
+
 									if (!isDefaultGrey) {
 										// Store as string for Set deduplication (e.g., "255,0,0,255")
 										cwaColorMap[cwaId].add(alert.color.join(','))
@@ -584,18 +587,18 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 						}
 					}
 				})
-				
+
 				// Convert to format expected by useMultiAlertAnimation
 				const result: Record<string, any> = {}
 				Object.entries(cwaColorMap).forEach(([cwaId, colorSet]) => {
 					if (colorSet.size > 0) {
 						// Convert strings back to number arrays
-						const uniqueColors = Array.from(colorSet).map(c => c.split(',').map(Number))
-						
+						const uniqueColors = Array.from(colorSet).map((c) => c.split(',').map(Number))
+
 						result[cwaId] = {
 							hasAlert: true,
 							color: uniqueColors[0], // Use first color as static fallback
-							alerts: uniqueColors.map(color => ({ color }))
+							alerts: uniqueColors.map((color) => ({ color })),
 						}
 					}
 				})
@@ -608,7 +611,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 
 		// Use multi-alert animation hook for counties with 2+ alerts
 		const { animatedColors: animatedCountyColors } = useMultiAlertAnimation(currentFrameAlertMap, true)
-		
+
 		// Use multi-alert animation hook for CWA zones with 2+ alert types
 		const { animatedColors: animatedCwaColors } = useMultiAlertAnimation(currentFrameCwaAlertMap, true)
 
@@ -1426,13 +1429,55 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 		}
 
 		const handleDeckGLClick = (info: any) => {
+			console.log('handleDeckGLClick called with info:', info, 'onCountyClick:', !!onCountyClick, 'onCwaClick:', !!onCwaClick)
+
 			// Check if a storm icon was clicked
 			if (info && info.object && info.object.id && onStormClick) {
 				onStormClick(info.object.id)
 				return
 			}
 
-			// Check if a CWA zone was clicked
+			// Check if a county was clicked first (only in detail view when onCountyClick is provided)
+			// This allows county clicks to open the slideout panel with alert details
+			// County clicks take priority over CWA clicks in detail view
+			if (onCountyClick && info && info.coordinate) {
+				const [lon, lat] = info.coordinate
+				console.log('County click check - lat/lon:', lat, lon, 'selectedWFOId:', selectedWFOId)
+				const regionInfo = findRegionAtPoint(lat, lon, undefined, cwaZonesData, selectedWFOId)
+				console.log('County click - regionInfo:', regionInfo)
+
+				if (regionInfo?.type === 'county') {
+					// Get county data from current frame
+					const activeFrame = currentFrame < 0 ? 0 : currentFrame >= loadedFrames.length ? loadedFrames.length - 1 : currentFrame
+					const frame = loadedFrames[activeFrame]
+					console.log('County click - frame:', frame, 'activeFrame:', activeFrame)
+
+					if (frame && frame.data && 'features' in frame.data) {
+						// Find the county feature in the frame data
+						const countyFeature = frame.data.features.find((feature: any) => {
+							const featureId = feature.properties?.id || feature.properties?.ID
+							return featureId === regionInfo.id
+						})
+						console.log('County click - countyFeature:', countyFeature)
+
+						if (countyFeature) {
+							// Extract county data including alerts
+							const countyData = {
+								shape: countyFeature,
+								alerts: countyFeature.properties?.alerts || [],
+								properties: countyFeature.properties || {},
+							}
+
+							console.log('County click - calling onCountyClick with:', regionInfo.id, countyData)
+							// Call the callback with county ID and data
+							onCountyClick(regionInfo.id, countyData)
+							return // Don't process CWA click if county was clicked
+						}
+					}
+				}
+			}
+
+			// Check if a CWA zone was clicked (only if county wasn't clicked)
 			// Use the same lat/long detection as hover
 			if (onCwaClick && info && info.coordinate) {
 				const [lon, lat] = info.coordinate
@@ -1441,6 +1486,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 				if (regionInfo?.type === 'cwa' && regionInfo.wfoId) {
 					// Call the callback to navigate (route drives the state)
 					onCwaClick(regionInfo.id, regionInfo.wfoId)
+					return
 				}
 			}
 		}
@@ -1507,7 +1553,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 									},
 									// Keyboard controls
 									keyboard: true,
-							  }
+								}
 					}
 					layers={layers}
 					onViewStateChange={handleViewStateChange}

--- a/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
@@ -447,7 +447,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 		// Theme-aware colors (RGBA format)
 		const isDark = isDarkMode
 		// Memoize colors to prevent dependency changes on every render
-		const { oceanColor, worldColor, statesColor, borderColor, countyBorderColor, gridlineColor } = useMemo(() => {
+		const { oceanColor, worldColor, statesColor, borderColor, countyBorderColor, cwaBorderColor, gridlineColor } = useMemo(() => {
 			// Ocean: blue1 (#8aadcf) light / blue2 (#233544) dark
 			const oceanColor = isDark ? [35, 53, 68, 255] : [138, 173, 207, 255]
 			// World: grey2 (#d8d8d8) light / grey16 (#484848) dark
@@ -456,11 +456,13 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			const statesColor = isDark ? [95, 95, 95, 255] : [255, 255, 255, 255]
 			// State Borders: grey18 (#232323) light / grey15 (#505050) dark - darker
 			const borderColor = isDark ? [80, 80, 80, 255] : [35, 35, 35, 255]
+			// CWA Zone Borders: Between state and county borders - darker than counties, lighter than states
+			const cwaBorderColor = isDark ? [95, 95, 95, 255] : [60, 60, 60, 255]
 			// County Borders: grey14 (#6b6b6b) light / grey12 (#7a7a7a) dark - lighter than state borders
 			const countyBorderColor = isDark ? [122, 122, 122, 255] : [107, 107, 107, 255]
 			// Grid lines: more visible grey with higher opacity
 			const gridlineColor = isDark ? [120, 120, 120, 180] : [180, 180, 180, 180]
-			return { oceanColor, worldColor, statesColor, borderColor, countyBorderColor, gridlineColor }
+			return { oceanColor, worldColor, statesColor, borderColor, countyBorderColor, cwaBorderColor, gridlineColor }
 		}, [isDark])
 
 		// Load frames
@@ -648,7 +650,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 					hoveredCwaId,
 					selectedWFOId,
 					alertMap: currentFrameCwaAlertMap,
-					countyBorderColor,
+					cwaBorderColor,
 					animatedColors: animatedCwaColors,
 					renderMode: 'fill',
 				}),
@@ -715,7 +717,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 					hoveredCwaId,
 					selectedWFOId,
 					alertMap: currentFrameCwaAlertMap,
-					countyBorderColor,
+					cwaBorderColor,
 					animatedColors: animatedCwaColors,
 					renderMode: 'border',
 				}),
@@ -1069,6 +1071,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			statesColor,
 			borderColor,
 			countyBorderColor,
+			cwaBorderColor,
 			gridlineColor,
 			currentFrameAlertMap,
 			currentFrameCoastalAlertMap,
@@ -1081,7 +1084,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			viewState.zoom,
 			selectedWFOId,
 			countyToCwaMap,
-			cwaZonesData?.features,
+			cwaZonesData,
 		])
 
 		const handleViewStateChange = (viewState: any) => {

--- a/src/components/elements/Animator/AnimatorMapMachine/layers/CwaZonesLayer.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/layers/CwaZonesLayer.tsx
@@ -7,14 +7,14 @@ export interface CwaZonesLayerProps {
 	hoveredCwaId: string | null
 	selectedWFOId?: string | null // Selected WFO ID for highlighting in detail view
 	alertMap: Record<string, any> | null // Alert data aggregated by CWA ID
-	countyBorderColor: number[] // Border color matching counties
+	cwaBorderColor: number[] // Border color for CWA zones - darker than counties, lighter than states
 	animatedColors?: Record<string, number[]> // Animated colors for multi-alert CWAs
 	renderMode?: 'both' | 'fill' | 'border' // Control what to render for layering
 }
 
 /**
  * CwaZonesLayer - Renders CWA (County Warning Areas) zones with alert-based coloring
- * Uses the same color scheme as counties for consistency
+ * Uses darker borders than counties for better visual hierarchy
  * Highlights the selected WFO region in detail view with a subtle tint
  * Supports multi-alert animation for CWAs containing multiple alert types
  */
@@ -24,7 +24,7 @@ export const createCwaZonesLayer = ({
 	hoveredCwaId,
 	selectedWFOId,
 	alertMap,
-	countyBorderColor,
+	cwaBorderColor,
 	animatedColors,
 	renderMode = 'both',
 }: CwaZonesLayerProps) => {
@@ -49,8 +49,8 @@ export const createCwaZonesLayer = ({
 					// Subtle blue border for selected zone
 					return [100, 150, 200, 200]
 				}
-				// Use county-style grey border (hover handled by highlight layer)
-				return countyBorderColor as any
+				// Use darker CWA border color for better visual hierarchy
+				return cwaBorderColor as any
 			},
 			getFillColor: (d: any) => {
 				const cwaId = d.properties?.CWA
@@ -81,7 +81,7 @@ export const createCwaZonesLayer = ({
 			},
 			opacity: 1,
 			updateTriggers: {
-				getLineColor: [hoveredCwaId, selectedWFOId, countyBorderColor],
+				getLineColor: [hoveredCwaId, selectedWFOId, cwaBorderColor],
 				getFillColor: [hoveredCwaId, selectedWFOId, alertMap, animatedColors],
 			},
 		}),

--- a/src/components/elements/Animator/AnimatorMapMachine/types.ts
+++ b/src/components/elements/Animator/AnimatorMapMachine/types.ts
@@ -104,6 +104,9 @@ export interface IAnimatorMapMachineProps {
 	onCwaClick?: (cwaId: string, wfoId: string) => void
 	selectedWFOId?: string | null // Selected WFO ID for filtering counties in detail view
 
+	// County interaction
+	onCountyClick?: (countyId: string, countyData: any) => void
+
 	// Callbacks
 	onFrameChange?: (frameIndex: number) => void
 	onViewStateChange?: (viewState: MapViewState) => void

--- a/src/components/elements/Animator/AnimatorMapSizer/AnimatorMapSizer.tsx
+++ b/src/components/elements/Animator/AnimatorMapSizer/AnimatorMapSizer.tsx
@@ -48,6 +48,7 @@ const AnimatorMapSizer = () => {
 		layerConfig,
 		onStormClick,
 		onCwaClick,
+		onCountyClick,
 		selectedWFOId,
 	} = useAnimator()
 
@@ -257,6 +258,7 @@ const AnimatorMapSizer = () => {
 					mapDataType={mapDataType}
 					onStormClick={onStormClick}
 					onCwaClick={onCwaClick}
+					onCountyClick={onCountyClick}
 					selectedWFOId={selectedWFOId}
 				/>
 			</div>

--- a/src/components/elements/WFOAnimator/WFOAnimator.tsx
+++ b/src/components/elements/WFOAnimator/WFOAnimator.tsx
@@ -3,8 +3,9 @@
 import { Animator } from '@/components/elements/Animator/Animator'
 import { MapFrame } from '@/components/elements/Animator/AnimatorMapMachine/types'
 import { zoomToCwaZone } from '@/components/elements/Animator/AnimatorMapMachine/utils/mapZoomUtils'
-import { mapZoomState } from '@/types/general'
 import cwaZonesData from '@/data/d3Map/cwaZones.json'
+import { useRootStore } from '@/store/useRootStore'
+import { mapZoomState } from '@/types/general'
 import { createCountyAlertFrame } from '@/util/dataCalls/alerts/createCountyAlertFrames'
 import { fetchRealTimeHazards, parseHazardsToCountyMap } from '@/util/dataCalls/alerts/parseCountyAlerts'
 import { useRouter } from 'next/navigation'
@@ -18,6 +19,9 @@ interface WFOAnimatorProps {
 
 export const WFOAnimator = ({ selectedWFOId, view = 'overview' }: WFOAnimatorProps) => {
 	const router = useRouter()
+	const openSlideoutPanel = useRootStore.use.openSlideoutPanel()
+	const setSelectedCounty = useRootStore.use.setSelectedCounty()
+	const setRegionHazards = useRootStore.use.setRegionHazards()
 	const [frames, setFrames] = useState<MapFrame[]>([])
 	const [isLoading, setIsLoading] = useState(true)
 	const [error, setError] = useState<string | null>(null)
@@ -52,6 +56,117 @@ export const WFOAnimator = ({ selectedWFOId, view = 'overview' }: WFOAnimatorPro
 			router.push(`${wfoBasePath}/${wfoId}`)
 		},
 		[router],
+	)
+
+	// Handle county click - open slideout panel with alert details
+	// Only works in detail view (onCountyClick is only passed in detail mode)
+	const handleCountyClick = useCallback(
+		(countyId: string, countyData: any) => {
+			// Only handle county clicks in detail view
+			if (view !== 'detail') return
+
+			console.log(`County clicked: ${countyId}`, countyData)
+
+			// Transform alerts from HazardData format to match hazards page structure
+			// The hazards page expects alerts with hazardInfo property containing type, level, and color
+			const transformedAlerts = (countyData.alerts || []).map((alert: any) => {
+				// If alert already has hazardInfo, use it as-is
+				if (alert.hazardInfo) {
+					return alert
+				}
+
+				// Otherwise, transform from HazardData format
+				// Extract type and level from hazardType and hazardLevel fields
+				const hazardType = alert.hazardType || 'UNKNOWN'
+				const hazardLevel = alert.hazardLevel || 'UNKNOWN'
+
+				// Map type and level to display names
+				// Using inline mappings to avoid import issues
+				const HAZARD_TYPE_NAMES_MAP: Record<string, string> = {
+					TORNADO: 'Tornado',
+					SEVERE: 'SEVERE',
+					FIRE: 'FIRE',
+					HYDROLOGICAL: 'Hydro',
+					MARINE: 'Marine',
+					NONMET: 'Non-Met',
+					NONPRECIP: 'Non-Precip',
+					TROPICAL: 'Tropical',
+					WINTER: 'Winter',
+					SPECIALWX: 'Special',
+				}
+
+				const HAZARD_LEVEL_NAMES_MAP: Record<string, string> = {
+					WARNING: 'Warning',
+					WATCH: 'Watch',
+					ADVISORY: 'Advisory',
+					STATEMENT: 'Statement',
+				}
+
+				const hazardTypeName = HAZARD_TYPE_NAMES_MAP[hazardType] || hazardType
+				const hazardLevelName = HAZARD_LEVEL_NAMES_MAP[hazardLevel] || hazardLevel
+
+				// Parse color - it can be either:
+				// 1. An object with hex/rgb properties from the API
+				// 2. An RGBA array [r, g, b, a] from parseHazardsToCountyMap
+				let hexColor = '#808080' // Default grey
+
+				if (alert.color) {
+					if (typeof alert.color === 'object' && 'hex' in alert.color) {
+						// API format: { hex: '#FF0000', rgb: '255,0,0' }
+						hexColor = alert.color.hex
+					} else if (Array.isArray(alert.color) && alert.color.length >= 3) {
+						// RGBA array format: [255, 0, 0, 255]
+						const [r, g, b] = alert.color
+						hexColor = `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
+					}
+				}
+
+				console.log('Alert color transformation:', {
+					originalColor: alert.color,
+					hexColor,
+					hazardType,
+					hazardLevel,
+				})
+
+				return {
+					...alert,
+					hazardInfo: {
+						type: {
+							type: hazardType,
+							name: hazardTypeName,
+						},
+						level: {
+							level: hazardLevel,
+							name: hazardLevelName,
+						},
+						color: {
+							HEX: hexColor,
+						},
+					},
+				}
+			})
+
+			// Format county data to match hazards page structure
+			// The regionHazards state expects a Record where keys are county IDs
+			// and values contain {shape, alerts, properties}
+			const formattedRegionHazards = {
+				[countyId]: {
+					shape: countyData.shape,
+					alerts: transformedAlerts,
+					properties: countyData.properties,
+				},
+			}
+
+			// Update zustand store with county data
+			setRegionHazards(formattedRegionHazards)
+			setSelectedCounty(countyId)
+
+			// Open slideout panel - HazardsDetailPanel will read from the store
+			// Using the constant from @/data/vars
+			const SLIDEOUT_PANEL_ID = 'DATA_TEXT_HAZARDS_MAP_DETAILS_SLIDEOUT'
+			openSlideoutPanel(SLIDEOUT_PANEL_ID)
+		},
+		[view, setRegionHazards, setSelectedCounty, openSlideoutPanel],
 	)
 
 	// Update target zoom state when view or selectedWFOId changes
@@ -175,10 +290,11 @@ export const WFOAnimator = ({ selectedWFOId, view = 'overview' }: WFOAnimatorPro
 				layerConfig={layerConfig}
 				autoPlay={false}
 				interval={500}
-				hideControls={view === 'detail'} // Hide controls in detail view (single frame, no animation needed)
+				hideControls={true} // Hide controls - WFO animator only shows a single frame (current alerts), no animation needed
 				mapLayerVisibility={mapLayerVisibility}
 				setMapLayerVisibility={setMapLayerVisibility}
 				onCwaClick={handleCwaClick} // Enable CWA clicks in both overview and detail view
+				onCountyClick={view === 'detail' ? handleCountyClick : undefined} // Enable county clicks only in detail view
 				selectedWFOId={view === 'detail' ? selectedWFOId : null} // Pass selected WFO for filtering
 				initialMapZoomState={targetZoomState}
 				setMapZoomState={handleMapZoomStateChange}

--- a/src/components/elements/WFOAnimator/WFOAnimator.tsx
+++ b/src/components/elements/WFOAnimator/WFOAnimator.tsx
@@ -275,8 +275,9 @@ export const WFOAnimator = ({ selectedWFOId, view = 'overview' }: WFOAnimatorPro
 					'cwa-zones-fill-layer': { active: true, initialValue: true }, // Keep CWA zones visible
 					'counties-inactive-layer': { active: true, initialValue: true }, // Only counties in selected WFO
 					'county-data-regions-layer': { active: true, initialValue: true }, // Only counties in selected WFO
-					'coastal-regions-inactive-layer': { active: true, initialValue: false },
-					'coastal-data-regions-layer': { active: true, initialValue: false },
+					// Coastal regions removed from WFO page - not needed for WFO office alerts
+					'coastal-regions-inactive-layer': { active: false, initialValue: false },
+					'coastal-data-regions-layer': { active: false, initialValue: false },
 				}
 
 	return (


### PR DESCRIPTION
## Description
Implements county click-through functionality for WFO detail view and adjusts map styling for better visual hierarchy.

### Changes Made
- Added county click support to WFO detail view - clicking counties opens slideout panel with alert details
- Removed coastal region layers from WFO page (not needed for WFO office-specific views)
- Adjusted CWA zone border colors for better visual hierarchy in dark mode
- Added data transformation to convert REST API alert format to GraphQL format for slideout panel
- Implemented color format handling for both hex objects and RGBA arrays

### Technical Details
- Added onCountyClick prop chain through Animator → AnimatorMapSizer → AnimatorMapMachine → WFOAnimator
- County clicks take priority over CWA clicks in detail view with early return logic
- Alert data transformation maps hazardType/hazardLevel to nested hazardInfo structure
- Color handling supports both {hex: '#FF0000', rgb: '255,0,0'} and [255, 0, 0, 255] formats
- CWA border colors now darker in dark mode: [95,95,95] vs county borders [122,122,122]
- Coastal layers set to active: false in WFO layer configuration

### Testing
- Navigate to WFO detail view
- Click on counties with alerts - slideout panel should open with county name, state, and alerts
- Verify alert boxes show correct colors (not grey)
- Verify CWA zone borders are more visible in dark mode
- Verify coastal region layers are hidden on WFO page
- Verify clicking different counties updates the slideout panel
- Verify existing CWA zone click navigation still works on overview page

## Related Monday Items
- NXL-18386644333
- NXL-18386653444

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes generate no new warnings
- [x] Dependent changes have been merged