### PR TITLE
Feature/nxl 10670595174 update wfo hazards to use animator map machine

### DIFF
--- a/src/app/weather-data/text-hazards-outlooks/active-weather-hazards/page.tsx
+++ b/src/app/weather-data/text-hazards-outlooks/active-weather-hazards/page.tsx
@@ -45,7 +45,8 @@ const Page = async () => {
 			if (region && region.coasts) {
 				region.coasts.forEach((coasts) => {
 					if (coasts && coasts.type && coasts.geometry) {
-						const optimizedCoast = { type: coasts.type, geometry: coasts.geometry, properties: {} }
+						// Include properties (ID, NAME) for coastal region identification
+						const optimizedCoast = { type: coasts.type, geometry: coasts.geometry, properties: coasts.properties || {} }
 						displayOffshoreRegions.push(rewind(optimizedCoast as AllGeoJSON, { reverse: true }))
 					}
 				})
@@ -53,7 +54,8 @@ const Page = async () => {
 			if (region && region.offshores) {
 				region.offshores.forEach((offshores) => {
 					if (offshores && offshores.type && offshores.geometry) {
-						const optimizedOffshore = { type: offshores.type, geometry: offshores.geometry, properties: {} }
+						// Include properties (ID, NAME) for offshore region identification
+						const optimizedOffshore = { type: offshores.type, geometry: offshores.geometry, properties: offshores.properties || {} }
 						displayOffshoreRegions.push(rewind(optimizedOffshore as AllGeoJSON, { reverse: true }))
 					}
 				})

--- a/src/components/blocks/Hazards/Hazards.tsx
+++ b/src/components/blocks/Hazards/Hazards.tsx
@@ -1,9 +1,13 @@
 'use client'
+import { HazardsAnimator } from '@/components/elements/HazardsAnimator'
 import MobileIconNav from '@/components/layout/MobileIconNav/MobileIconNav'
 import { useRootStore } from '@/store/useRootStore'
 import { useEffect } from 'react'
 import HazardsMap from './HazardsMap/HazardsMap'
 import HazardsTable from './HazardsTable/HazardsTable'
+
+// Feature flag to toggle between old D3 map and new Animator map
+const USE_ANIMATOR_MAP = true
 
 const Hazards = ({ displayRegions, displayStates, displayOffshores, alerts }) => {
 	const selectedView = useRootStore.use.selectedView()
@@ -16,8 +20,9 @@ const Hazards = ({ displayRegions, displayStates, displayOffshores, alerts }) =>
 		setAllHazards(alerts)
 	}, [setAllHazards, alerts])
 
+	// Only set region hazards for the old D3 map - HazardsAnimator handles this internally
 	useEffect(() => {
-		if (selectedRegion && Object.keys(allHazards).length !== 0) {
+		if (!USE_ANIMATOR_MAP && selectedRegion && Object.keys(allHazards).length !== 0) {
 			const ids = {
 				conus: 'Continental United States',
 				ak: 'Alaska',
@@ -35,7 +40,11 @@ const Hazards = ({ displayRegions, displayStates, displayOffshores, alerts }) =>
 			{Object.keys(allHazards).length !== 0 ? (
 				<>
 					{selectedView === 'map' ? (
-						<HazardsMap displayRegions={displayRegions} displayStates={displayStates} displayOffshores={displayOffshores} />
+						USE_ANIMATOR_MAP ? (
+							<HazardsAnimator alerts={allHazards} />
+						) : (
+							<HazardsMap displayRegions={displayRegions} displayStates={displayStates} displayOffshores={displayOffshores} />
+						)
 					) : null}
 					{selectedView === 'table' ? <HazardsTable /> : null}
 				</>

--- a/src/components/blocks/Hazards/Hazards.tsx
+++ b/src/components/blocks/Hazards/Hazards.tsx
@@ -41,7 +41,7 @@ const Hazards = ({ displayRegions, displayStates, displayOffshores, alerts }) =>
 				<>
 					{selectedView === 'map' ? (
 						USE_ANIMATOR_MAP ? (
-							<HazardsAnimator alerts={allHazards} />
+							<HazardsAnimator alerts={allHazards} allCoastalRegions={displayOffshores} />
 						) : (
 							<HazardsMap displayRegions={displayRegions} displayStates={displayStates} displayOffshores={displayOffshores} />
 						)

--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -75,6 +75,8 @@ export interface IAnimatorProps {
 	onCountyClick?: (countyId: string, countyData: any) => void
 	// Selected WFO ID for filtering counties in detail view
 	selectedWFOId?: string | null
+	// Disable CWA zone hover/click detection entirely (for hazards page)
+	disableCwaDetection?: boolean
 }
 interface IAnimatorProvider extends IAnimatorProps {
 	loadedFrames: any[] // Replace `any` with the actual type of frames
@@ -97,6 +99,7 @@ interface IAnimatorProvider extends IAnimatorProps {
 	mapDataType: 'alerts' | 'hurricane' | 'all' // Type of data being displayed
 	layerConfig?: any // Layer configuration for filtering which layers are shown
 	selectedWFOId?: string | null // Selected WFO ID for filtering counties in detail view
+	disableCwaDetection?: boolean // Disable CWA zone hover/click detection entirely
 }
 
 const AnimatorContext = createContext<IAnimatorProvider | undefined>(undefined)
@@ -178,6 +181,7 @@ export const Animator = ({
 	onCwaClick,
 	onCountyClick,
 	selectedWFOId,
+	disableCwaDetection = false,
 }: IAnimatorProps) => {
 	const [isPlaying, setIsPlaying] = useState(false)
 	const [loadedFrames, setLoadedFrames] = useState([])
@@ -351,6 +355,7 @@ export const Animator = ({
 				onCwaClick,
 				onCountyClick,
 				selectedWFOId,
+				disableCwaDetection,
 			}}
 		>
 			<AnimatorLayout />

--- a/src/components/elements/Animator/Animator.tsx
+++ b/src/components/elements/Animator/Animator.tsx
@@ -77,6 +77,10 @@ export interface IAnimatorProps {
 	selectedWFOId?: string | null
 	// Disable CWA zone hover/click detection entirely (for hazards page)
 	disableCwaDetection?: boolean
+	// Hazard filter for sidebar hover interaction - returns opacity 0-1 for counties
+	hazardOpacityFn?: (alerts: any[]) => number
+	// All coastal/offshore regions for showing inactive borders (not just those with alerts)
+	allCoastalRegions?: any
 }
 interface IAnimatorProvider extends IAnimatorProps {
 	loadedFrames: any[] // Replace `any` with the actual type of frames
@@ -100,6 +104,8 @@ interface IAnimatorProvider extends IAnimatorProps {
 	layerConfig?: any // Layer configuration for filtering which layers are shown
 	selectedWFOId?: string | null // Selected WFO ID for filtering counties in detail view
 	disableCwaDetection?: boolean // Disable CWA zone hover/click detection entirely
+	hazardOpacityFn?: (alerts: any[]) => number // Hazard filter for sidebar hover
+	allCoastalRegions?: any // All coastal/offshore regions for showing inactive borders
 }
 
 const AnimatorContext = createContext<IAnimatorProvider | undefined>(undefined)
@@ -182,6 +188,8 @@ export const Animator = ({
 	onCountyClick,
 	selectedWFOId,
 	disableCwaDetection = false,
+	hazardOpacityFn,
+	allCoastalRegions,
 }: IAnimatorProps) => {
 	const [isPlaying, setIsPlaying] = useState(false)
 	const [loadedFrames, setLoadedFrames] = useState([])
@@ -356,6 +364,8 @@ export const Animator = ({
 				onCountyClick,
 				selectedWFOId,
 				disableCwaDetection,
+				hazardOpacityFn,
+				allCoastalRegions,
 			}}
 		>
 			<AnimatorLayout />

--- a/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
@@ -227,6 +227,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			onCwaClick,
 			onCountyClick,
 			selectedWFOId,
+			disableCwaDetection = false,
 		},
 		ref,
 	) => {
@@ -1320,10 +1321,11 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 
 							// Find which region (county, coastal, or CWA) this point is in
 							// Pass selectedWFOId to skip the selected WFO zone in detail view
-							const regionInfo = findRegionAtPoint(lat, lon, coastalData, cwaZonesData, selectedWFOId)
+							// Pass undefined for cwaData when disableCwaDetection is true to skip CWA zones entirely
+							const regionInfo = findRegionAtPoint(lat, lon, coastalData, disableCwaDetection ? undefined : cwaZonesData, selectedWFOId)
 
 							// Handle CWA hover separately from county/coastal hover
-							if (regionInfo?.type === 'cwa') {
+							if (regionInfo?.type === 'cwa' && !disableCwaDetection) {
 								setHoveredCwaId(regionInfo.id)
 								setHoveredCwaWfoId(regionInfo.wfoId || null)
 								setHoveredCountyId(null)
@@ -1362,10 +1364,11 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 				const hoverLat = centerLat + offsetLat
 
 				// Pass selectedWFOId to skip the selected WFO zone in detail view
-				const regionInfo = findRegionAtPoint(hoverLat, hoverLon, coastalData, cwaZonesData, selectedWFOId)
+				// Pass undefined for cwaData when disableCwaDetection is true to skip CWA zones entirely
+				const regionInfo = findRegionAtPoint(hoverLat, hoverLon, coastalData, disableCwaDetection ? undefined : cwaZonesData, selectedWFOId)
 
 				// Handle CWA hover separately from county/coastal hover
-				if (regionInfo?.type === 'cwa') {
+				if (regionInfo?.type === 'cwa' && !disableCwaDetection) {
 					setHoveredCwaId(regionInfo.id)
 					setHoveredCwaWfoId(regionInfo.wfoId || null)
 					setHoveredCountyId(null)
@@ -1396,6 +1399,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 				setTooltipVisible,
 				setCwaTooltipVisible,
 				selectedWFOId,
+				disableCwaDetection,
 			],
 		)
 
@@ -1446,7 +1450,8 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			if (onCountyClick && info && info.coordinate) {
 				const [lon, lat] = info.coordinate
 				console.log('County click check - lat/lon:', lat, lon, 'selectedWFOId:', selectedWFOId)
-				const regionInfo = findRegionAtPoint(lat, lon, undefined, cwaZonesData, selectedWFOId)
+				// Pass undefined for cwaData when disableCwaDetection is true to skip CWA zones entirely
+				const regionInfo = findRegionAtPoint(lat, lon, undefined, disableCwaDetection ? undefined : cwaZonesData, selectedWFOId)
 				console.log('County click - regionInfo:', regionInfo)
 
 				if (regionInfo?.type === 'county') {
@@ -1480,9 +1485,9 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 				}
 			}
 
-			// Check if a CWA zone was clicked (only if county wasn't clicked)
+			// Check if a CWA zone was clicked (only if county wasn't clicked and CWA detection is enabled)
 			// Use the same lat/long detection as hover
-			if (onCwaClick && info && info.coordinate) {
+			if (onCwaClick && !disableCwaDetection && info && info.coordinate) {
 				const [lon, lat] = info.coordinate
 				const regionInfo = findRegionAtPoint(lat, lon, undefined, cwaZonesData)
 

--- a/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/AnimatorMapMachine.tsx
@@ -228,6 +228,8 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			onCountyClick,
 			selectedWFOId,
 			disableCwaDetection = false,
+			hazardOpacityFn,
+			allCoastalRegions,
 		},
 		ref,
 	) => {
@@ -664,7 +666,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 
 				// Lat/Long grid layer
 				...createLatLongGridLayer({
-					visible: shouldShowLayer('latlong-grid'),
+					visible: shouldShowLayer('latlon-grid-layer'),
 					gridlineColor,
 				}),
 
@@ -682,34 +684,29 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 
 				// Counties layer (Fill + Borders)
 				// Rendered here so it sits on top of State/CWA fills but below their borders
-				...(selectedWFOId || viewState.zoom > 4.5
-					? createCountiesLayer({
-							data:
-								loadedFrames.length > 0
-									? loadedFrames[
-											currentFrame < 0 ? 0 : currentFrame >= loadedFrames.length ? loadedFrames.length - 1 : currentFrame
-										]?.data
-									: null,
-							showInactiveBorders: shouldShowLayer('counties-inactive-layer'),
-							showAlertData: shouldShowLayer('county-data-regions-layer'),
-							countyBorderColor,
-							hoveredCountyId,
-							alertMap: currentFrameAlertMap,
-							animatedColors: animatedCountyColors,
-							filterCountyFn: selectedWFOId
-								? (countyId: string) => {
-										// Find the CWA ID for this WFO
-										const cwaFeature = cwaZonesData?.features?.find(
-											(f: any) => f.properties?.FULLSTAID === selectedWFOId || f.properties?.WFO === selectedWFOId,
-										)
-										const cwaId = cwaFeature?.properties?.CWA
-										if (!cwaId) return false
-										// Check if this county belongs to the selected CWA
-										return countyToCwaMap.get(countyId) === cwaId
-									}
-								: undefined,
-						})
-					: []),
+				// Uses static countiesData for all counties, alertMap for coloring counties with alerts
+				...createCountiesLayer({
+					data: countiesData,
+					showInactiveBorders: shouldShowLayer('counties-inactive-layer'),
+					showAlertData: shouldShowLayer('county-data-regions-layer'),
+					countyBorderColor,
+					hoveredCountyId,
+					alertMap: currentFrameAlertMap,
+					animatedColors: animatedCountyColors,
+					filterCountyFn: selectedWFOId
+						? (countyId: string) => {
+								// Find the CWA ID for this WFO
+								const cwaFeature = cwaZonesData?.features?.find(
+									(f: any) => f.properties?.FULLSTAID === selectedWFOId || f.properties?.WFO === selectedWFOId,
+								)
+								const cwaId = cwaFeature?.properties?.CWA
+								if (!cwaId) return false
+								// Check if this county belongs to the selected CWA
+								return countyToCwaMap.get(countyId) === cwaId
+							}
+						: undefined,
+					hazardOpacityFn,
+				}),
 
 				// CWA Zones Border Layer (Top of regions)
 				...createCwaZonesLayer({
@@ -733,11 +730,7 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 
 				// Coastal regions layer
 				...createCoastalRegionsLayer({
-					data:
-						loadedFrames.length > 0
-							? loadedFrames[currentFrame < 0 ? 0 : currentFrame >= loadedFrames.length ? loadedFrames.length - 1 : currentFrame]
-									?.coastalData
-							: null,
+					allCoastalRegions: allCoastalRegions,
 					showInactiveBorders: shouldShowLayer('coastal-regions-inactive-layer'),
 					showAlertData: shouldShowLayer('coastal-data-regions-layer'),
 					oceanColor,
@@ -1082,10 +1075,11 @@ export const AnimatorMapMachine = forwardRef<HTMLDivElement, IAnimatorMapMachine
 			animatedCwaColors,
 			currentFrameCwaAlertMap,
 			initializedLayerVisibility,
-			viewState.zoom,
 			selectedWFOId,
 			countyToCwaMap,
 			cwaZonesData,
+			hazardOpacityFn,
+			allCoastalRegions,
 		])
 
 		const handleViewStateChange = (viewState: any) => {

--- a/src/components/elements/Animator/AnimatorMapMachine/layers/CoastalRegionsLayer.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/layers/CoastalRegionsLayer.tsx
@@ -1,11 +1,28 @@
 import { GeoJsonLayer } from '@deck.gl/layers'
 
 export interface CoastalRegionsLayerProps {
-	data: any
+	/** All coastal/offshore regions (for showing inactive borders) */
+	allCoastalRegions: any
 	showInactiveBorders: boolean
 	showAlertData: boolean
 	oceanColor: number[]
 	alertMap: Record<string, any> | null
+}
+
+/**
+ * Helper function to get region ID from feature properties
+ * Handles different property formats from API data
+ */
+const getRegionId = (feature: any): string | null => {
+	const props = feature.properties
+	if (!props) return null
+	// Try common ID property names
+	if (props.id) return props.id
+	if (props.ID) return props.ID
+	if (props.Id) return props.Id
+	if (props.CODE) return props.CODE
+	if (props.NAME) return props.NAME
+	return null
 }
 
 /**
@@ -15,19 +32,26 @@ export interface CoastalRegionsLayerProps {
  * - showInactiveBorders: Controls border opacity for regions without alerts (0 opacity when off, except for hovered)
  * - showAlertData: Controls whether to show alert colors and hover interactivity (when off, all fills are ocean color)
  */
-export const createCoastalRegionsLayer = ({ data, showInactiveBorders, showAlertData, oceanColor, alertMap }: CoastalRegionsLayerProps) => {
-	if (!data) return []
+export const createCoastalRegionsLayer = ({
+	allCoastalRegions,
+	showInactiveBorders,
+	showAlertData,
+	oceanColor,
+	alertMap,
+}: CoastalRegionsLayerProps) => {
+	// Use allCoastalRegions as the base data (contains ALL coastal regions, not just those with alerts)
+	if (!allCoastalRegions) return []
 
 	return [
 		new GeoJsonLayer({
 			id: 'coastal-regions-layer',
-			data: data as any,
+			data: allCoastalRegions as any,
 			filled: true,
 			stroked: true,
 			lineWidthMinPixels: 0.5,
 			lineWidthMaxPixels: 1,
 			getLineColor: (d: any) => {
-				const regionId = d.properties?.id || d.properties?.ID
+				const regionId = getRegionId(d)
 				const alertInfo = alertMap && regionId && alertMap[regionId]
 				const hasAlert = alertInfo?.hasAlert
 
@@ -48,7 +72,7 @@ export const createCoastalRegionsLayer = ({ data, showInactiveBorders, showAlert
 				return [100, 100, 100, 100]
 			},
 			getFillColor: (d: any) => {
-				const regionId = d.properties?.id || d.properties?.ID
+				const regionId = getRegionId(d)
 				const alertInfo = alertMap && regionId && alertMap[regionId]
 				const hasAlert = alertInfo?.hasAlert
 

--- a/src/components/elements/Animator/AnimatorMapMachine/layers/CountiesLayer.tsx
+++ b/src/components/elements/Animator/AnimatorMapMachine/layers/CountiesLayer.tsx
@@ -9,6 +9,29 @@ export interface CountiesLayerProps {
 	alertMap: Record<string, any> | null
 	animatedColors?: Record<string, number[]>
 	filterCountyFn?: (countyId: string) => boolean // Optional filter function to show only specific counties
+	hazardOpacityFn?: (alerts: any[]) => number // Optional function to determine opacity based on alerts (for sidebar hover filtering)
+}
+
+/**
+ * Extract county ID from feature properties
+ * Handles multiple property formats: id, ID, CODE_LOCAL, or FIPS (extracts numeric part)
+ */
+const getCountyId = (feature: any): string | null => {
+	const props = feature.properties
+	if (!props) return null
+
+	// Try direct id properties first
+	if (props.id) return props.id
+	if (props.ID) return props.ID
+	if (props.CODE_LOCAL) return props.CODE_LOCAL
+
+	// Try FIPS format (e.g., "US53073" -> "53073")
+	if (props.FIPS) {
+		const fipsMatch = props.FIPS.match(/(\d{5})/)
+		return fipsMatch ? fipsMatch[1] : null
+	}
+
+	return null
 }
 
 /**
@@ -27,6 +50,7 @@ export const createCountiesLayer = ({
 	alertMap,
 	animatedColors,
 	filterCountyFn,
+	hazardOpacityFn,
 }: CountiesLayerProps) => {
 	if (!data) return []
 
@@ -36,7 +60,7 @@ export const createCountiesLayer = ({
 		filteredData = {
 			...data,
 			features: data.features.filter((feature: any) => {
-				const countyId = feature.properties?.id || feature.properties?.ID
+				const countyId = getCountyId(feature)
 				if (!countyId) return false
 				return filterCountyFn(countyId)
 			}),
@@ -52,7 +76,7 @@ export const createCountiesLayer = ({
 			lineWidthMinPixels: 0.5,
 			lineWidthMaxPixels: 1,
 			getLineColor: (d: any) => {
-				const regionId = d.properties?.id || d.properties?.ID
+				const regionId = getCountyId(d)
 				const alertInfo = alertMap && regionId && alertMap[regionId]
 				const hasAlert = alertInfo?.hasAlert
 
@@ -73,31 +97,41 @@ export const createCountiesLayer = ({
 				return countyBorderColor as any
 			},
 			getFillColor: (d: any) => {
-				const regionId = d.properties?.id || d.properties?.ID
+				const regionId = getCountyId(d)
 				const alertInfo = alertMap && regionId && alertMap[regionId]
 				const hasAlert = alertInfo?.hasAlert
+				const alerts = d.properties?.alerts || alertInfo?.alerts || []
 
 				// If county data is disabled, use default color for all counties
 				if (!showAlertData) {
 					return [200, 200, 200, 0]
 				}
 
+				// Calculate opacity from hazard filter (for sidebar hover interaction)
+				// Default opacity is 1 (fully visible), hazardOpacityFn returns 0-1
+				const filterOpacity = hazardOpacityFn ? hazardOpacityFn(alerts) : 1
+
 				// If county has alert and county data is enabled, show alert color
+				let baseColor: number[]
 				if (animatedColors && regionId && animatedColors[regionId]) {
-					return animatedColors[regionId]
-				}
-				if (hasAlert && alertInfo) {
-					return alertInfo.color
+					baseColor = animatedColors[regionId]
+				} else if (hasAlert && alertInfo) {
+					baseColor = alertInfo.color
+				} else {
+					// No alert - show default fill
+					return [200, 200, 200, 0]
 				}
 
-				// No alert - show default fill
-				return [200, 200, 200, 0]
+				// Apply filter opacity to the alpha channel
+				// baseColor is [R, G, B, A] - we multiply A by filterOpacity
+				const alpha = (baseColor[3] ?? 255) * filterOpacity
+				return [baseColor[0], baseColor[1], baseColor[2], alpha]
 			},
 			opacity: 1,
 			pickable: false, // Use lat/long-based detection instead of deck.gl picking
 			updateTriggers: {
 				getLineColor: [countyBorderColor, hoveredCountyId, showInactiveBorders, showAlertData, alertMap],
-				getFillColor: [showAlertData, alertMap, animatedColors],
+				getFillColor: [showAlertData, alertMap, animatedColors, hazardOpacityFn],
 			},
 		}),
 	]

--- a/src/components/elements/Animator/AnimatorMapMachine/types.ts
+++ b/src/components/elements/Animator/AnimatorMapMachine/types.ts
@@ -108,6 +108,13 @@ export interface IAnimatorMapMachineProps {
 	// County interaction
 	onCountyClick?: (countyId: string, countyData: any) => void
 
+	// Hazard filter for sidebar hover interaction
+	// Returns opacity 0-1 based on whether the county's alerts match the hovered hazard type/level
+	hazardOpacityFn?: (alerts: any[]) => number
+
+	// All coastal/offshore regions for showing inactive borders (not just those with alerts)
+	allCoastalRegions?: any
+
 	// Callbacks
 	onFrameChange?: (frameIndex: number) => void
 	onViewStateChange?: (viewState: MapViewState) => void

--- a/src/components/elements/Animator/AnimatorMapMachine/types.ts
+++ b/src/components/elements/Animator/AnimatorMapMachine/types.ts
@@ -103,6 +103,7 @@ export interface IAnimatorMapMachineProps {
 	// CWA zone interaction
 	onCwaClick?: (cwaId: string, wfoId: string) => void
 	selectedWFOId?: string | null // Selected WFO ID for filtering counties in detail view
+	disableCwaDetection?: boolean // Disable CWA zone hover/click detection entirely (for hazards page)
 
 	// County interaction
 	onCountyClick?: (countyId: string, countyData: any) => void

--- a/src/components/elements/Animator/AnimatorMapSizer/AnimatorMapSizer.tsx
+++ b/src/components/elements/Animator/AnimatorMapSizer/AnimatorMapSizer.tsx
@@ -50,6 +50,7 @@ const AnimatorMapSizer = () => {
 		onCwaClick,
 		onCountyClick,
 		selectedWFOId,
+		disableCwaDetection,
 	} = useAnimator()
 
 	// Debug logging - only for mouse/click interactions
@@ -260,6 +261,7 @@ const AnimatorMapSizer = () => {
 					onCwaClick={onCwaClick}
 					onCountyClick={onCountyClick}
 					selectedWFOId={selectedWFOId}
+					disableCwaDetection={disableCwaDetection}
 				/>
 			</div>
 

--- a/src/components/elements/Animator/AnimatorMapSizer/AnimatorMapSizer.tsx
+++ b/src/components/elements/Animator/AnimatorMapSizer/AnimatorMapSizer.tsx
@@ -51,6 +51,8 @@ const AnimatorMapSizer = () => {
 		onCountyClick,
 		selectedWFOId,
 		disableCwaDetection,
+		hazardOpacityFn,
+		allCoastalRegions,
 	} = useAnimator()
 
 	// Debug logging - only for mouse/click interactions
@@ -262,6 +264,8 @@ const AnimatorMapSizer = () => {
 					onCountyClick={onCountyClick}
 					selectedWFOId={selectedWFOId}
 					disableCwaDetection={disableCwaDetection}
+					hazardOpacityFn={hazardOpacityFn}
+					allCoastalRegions={allCoastalRegions}
 				/>
 			</div>
 

--- a/src/components/elements/HazardsAnimator/HazardsAnimator.module.scss
+++ b/src/components/elements/HazardsAnimator/HazardsAnimator.module.scss
@@ -1,0 +1,40 @@
+.hazardsAnimator {
+	width: 100%;
+	height: 100%;
+	position: relative;
+}
+
+.loading,
+.error {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	height: 100%;
+	width: 100%;
+	
+	p {
+		font-size: 1rem;
+		color: var(--text-primary);
+	}
+}
+
+.error p {
+	color: var(--error-color, #ff4444);
+}
+
+.fullScreenButton {
+	position: absolute;
+	bottom: 10px;
+	right: 10px;
+	z-index: 100;
+	cursor: pointer;
+	padding: 8px;
+	background: rgba(0, 0, 0, 0.5);
+	border-radius: 4px;
+	color: white;
+	
+	&:hover {
+		background: rgba(0, 0, 0, 0.7);
+	}
+}
+

--- a/src/components/elements/HazardsAnimator/HazardsAnimator.module.scss
+++ b/src/components/elements/HazardsAnimator/HazardsAnimator.module.scss
@@ -11,7 +11,7 @@
 	align-items: center;
 	height: 100%;
 	width: 100%;
-	
+
 	p {
 		font-size: 1rem;
 		color: var(--text-primary);
@@ -21,20 +21,3 @@
 .error p {
 	color: var(--error-color, #ff4444);
 }
-
-.fullScreenButton {
-	position: absolute;
-	bottom: 10px;
-	right: 10px;
-	z-index: 100;
-	cursor: pointer;
-	padding: 8px;
-	background: rgba(0, 0, 0, 0.5);
-	border-radius: 4px;
-	color: white;
-	
-	&:hover {
-		background: rgba(0, 0, 0, 0.7);
-	}
-}
-

--- a/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
+++ b/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { Animator } from '@/components/elements/Animator/Animator'
+import { LAYER_CONFIG_PRESETS } from '@/components/elements/Animator/AnimatorMapMachine/config/layerConfigTypes'
+import { MapFrame } from '@/components/elements/Animator/AnimatorMapMachine/types'
+import { DATA_TEXT_HAZARDS_MAP_DETAILS_SLIDEOUT } from '@/data/vars'
+import { useRootStore } from '@/store/useRootStore'
+import { mapZoomState } from '@/types/general'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import styles from './HazardsAnimator.module.scss'
+
+// Region view state configurations for different geographic regions
+// Note: Zoom must be > 4.5 for counties to show in AnimatorMapMachine
+const REGION_VIEW_STATES: Record<string, mapZoomState> = {
+	conus: { zoom: 4.6, latitude: 39.8283, longitude: -98.5795 },
+	ak: { zoom: 4.6, latitude: 64.2, longitude: -152 },
+	hi: { zoom: 6, latitude: 20.5, longitude: -157 },
+	pr: { zoom: 8, latitude: 18.21, longitude: -66 },
+	sam: { zoom: 8, latitude: -14.27, longitude: -170.7 },
+	gum: { zoom: 8, latitude: 13.45, longitude: 144.8 },
+}
+
+// Region name mapping (store uses short codes, API uses full names)
+const REGION_NAME_MAP: Record<string, string> = {
+	conus: 'Continental United States',
+	ak: 'Alaska',
+	hi: 'Hawaii',
+	pr: 'Puerto Rico',
+	sam: 'American Samoa',
+	gum: 'Guam',
+}
+
+interface HazardsAnimatorProps {
+	/** Pre-loaded alerts data from the server (from allHazards store) */
+	alerts: Record<string, Record<string, any>>
+}
+
+/**
+ * HazardsAnimator - Deck.gl map-based hazards visualization
+ *
+ * This component wraps the Animator with map mode to display
+ * weather hazards. It reads from the hazards store for:
+ * - selectedRegion: which region to display
+ * - regionHazards: the hazard data to visualize
+ * - activeHazards/Types/Levels: for sidebar hover highlighting
+ */
+export const HazardsAnimator = ({ alerts }: HazardsAnimatorProps) => {
+	const openSlideoutPanel = useRootStore.use.openSlideoutPanel()
+	const setSelectedCounty = useRootStore.use.setSelectedCounty()
+	const setRegionHazards = useRootStore.use.setRegionHazards()
+	const selectedRegion = useRootStore.use.selectedRegion()
+	const regionHazards = useRootStore.use.regionHazards()
+
+	const [frames, setFrames] = useState<MapFrame[]>([])
+	const [mapLayerVisibility, setMapLayerVisibility] = useState<Record<string, boolean>>({})
+	const [targetZoomState, setTargetZoomState] = useState<mapZoomState | undefined>(REGION_VIEW_STATES.conus)
+
+	// Update region hazards when alerts or selected region changes
+	useEffect(() => {
+		if (selectedRegion && alerts) {
+			const regionName = REGION_NAME_MAP[selectedRegion]
+			if (regionName && alerts[regionName]) {
+				setRegionHazards(alerts[regionName])
+			}
+		}
+	}, [selectedRegion, alerts, setRegionHazards])
+
+	// Update zoom state when region changes
+	useEffect(() => {
+		const viewState = REGION_VIEW_STATES[selectedRegion]
+		if (viewState) {
+			setTargetZoomState(viewState)
+		}
+	}, [selectedRegion])
+
+	// Convert regionHazards to MapFrame format
+	useEffect(() => {
+		if (!regionHazards || Object.keys(regionHazards).length === 0) {
+			setFrames([])
+			return
+		}
+
+		// Create GeoJSON features from regionHazards
+		const features = Object.entries(regionHazards).map(([countyId, data]: [string, any]) => {
+			const { shape, alerts: countyAlerts, properties } = data
+			const firstAlert = countyAlerts[0]
+			const alertColor = firstAlert?.hazardInfo?.color?.HEX || '#808080'
+
+			// Convert HEX color to RGBA array
+			const hexToRgba = (hex: string): [number, number, number, number] => {
+				const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+				if (result) {
+					return [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16), 255]
+				}
+				return [128, 128, 128, 255]
+			}
+
+			return {
+				type: 'Feature' as const,
+				geometry: shape.geometry,
+				properties: {
+					...properties,
+					id: countyId,
+					alertColor: hexToRgba(alertColor),
+					hasAlert: true,
+					alerts: countyAlerts.map((alert: any) => ({
+						...alert,
+						event: alert.event,
+						headline: alert.headline,
+						hazardType: alert.hazardInfo?.type?.type,
+						hazardLevel: alert.hazardInfo?.level?.level,
+						color: hexToRgba(alert.hazardInfo?.color?.HEX || '#808080'),
+					})),
+				},
+			}
+		})
+
+		const geoJSON = {
+			type: 'FeatureCollection' as const,
+			features,
+		}
+
+		const frame: MapFrame = {
+			id: 'current-hazards',
+			timestamp: new Date(),
+			data: geoJSON,
+			metadata: {
+				alertCount: features.length,
+				region: selectedRegion,
+			},
+		}
+
+		setFrames([frame])
+	}, [regionHazards, selectedRegion])
+
+	// Handle county click - open slideout panel with details
+	// Note: countyData is available but not used since we read from regionHazards store
+	const handleCountyClick = useCallback(
+		(countyId: string) => {
+			setSelectedCounty(countyId)
+			openSlideoutPanel(DATA_TEXT_HAZARDS_MAP_DETAILS_SLIDEOUT)
+		},
+		[setSelectedCounty, openSlideoutPanel],
+	)
+
+	// Handle zoom state updates from map interactions
+	const handleMapZoomStateChange = useCallback((newZoomState: mapZoomState) => {
+		setTargetZoomState(newZoomState)
+	}, [])
+
+	// Layer configuration for hazards display
+	// Based on COUNTY_ALERTS preset but with CWA zones explicitly disabled
+	const layerConfig = useMemo(
+		() => ({
+			...LAYER_CONFIG_PRESETS.COUNTY_ALERTS,
+			// Explicitly disable CWA zones - this is the hazards page, not the WFO page
+			'cwa-zones-inactive-layer': { active: false, initialValue: false },
+			'cwa-zones-fill-layer': { active: false, initialValue: false },
+		}),
+		[],
+	)
+
+	// Show empty state if no hazards for this region
+	if (frames.length === 0) {
+		return (
+			<div className={styles.hazardsAnimator}>
+				<div className={styles.loading}>
+					<p>No active hazards for this region</p>
+				</div>
+			</div>
+		)
+	}
+
+	return (
+		<div className={styles.hazardsAnimator}>
+			<Animator
+				frames={frames}
+				mode="map"
+				mapRegion="conus"
+				imageInfo={{ width: 1200, height: 800 }}
+				mapDataType="alerts"
+				layerConfig={layerConfig}
+				autoPlay={false}
+				interval={500}
+				hideControls={true}
+				mapLayerVisibility={mapLayerVisibility}
+				setMapLayerVisibility={setMapLayerVisibility}
+				onCountyClick={handleCountyClick}
+				initialMapZoomState={targetZoomState}
+				setMapZoomState={handleMapZoomStateChange}
+				disableCwaDetection={true}
+			/>
+		</div>
+	)
+}

--- a/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
+++ b/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
@@ -76,6 +76,10 @@ export const HazardsAnimator = ({ alerts, allCoastalRegions }: HazardsAnimatorPr
 	const setSelectedRegion = useRootStore.use.setSelectedRegion()
 	const regionHazards = useRootStore.use.regionHazards()
 
+	// Fullscreen state from store
+	const hazardMapFullScreen = useRootStore.use.hazardMapFullScreen()
+	const setHazardMapFullScreen = useRootStore.use.setHazardMapFullScreen()
+
 	// Hazard filter state from store (for sidebar hover interaction)
 	const isHazardVisible = useRootStore.use.isHazardVisible()
 	const anyActiveOrToggledHazards = useRootStore.use.anyActiveOrToggledHazards()
@@ -291,6 +295,8 @@ export const HazardsAnimator = ({ alerts, allCoastalRegions }: HazardsAnimatorPr
 				disableCwaDetection={true}
 				hazardOpacityFn={hazardOpacityFn}
 				allCoastalRegions={allCoastalRegions}
+				fullScreen={hazardMapFullScreen}
+				setFullScreen={setHazardMapFullScreen}
 			/>
 		</div>
 	)

--- a/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
+++ b/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
@@ -33,6 +33,8 @@ const REGION_NAME_MAP: Record<string, string> = {
 interface HazardsAnimatorProps {
 	/** Pre-loaded alerts data from the server (from allHazards store) */
 	alerts: Record<string, Record<string, any>>
+	/** All coastal/offshore regions (for showing inactive borders) */
+	allCoastalRegions?: any
 }
 
 /**
@@ -44,12 +46,16 @@ interface HazardsAnimatorProps {
  * - regionHazards: the hazard data to visualize
  * - activeHazards/Types/Levels: for sidebar hover highlighting
  */
-export const HazardsAnimator = ({ alerts }: HazardsAnimatorProps) => {
+export const HazardsAnimator = ({ alerts, allCoastalRegions }: HazardsAnimatorProps) => {
 	const openSlideoutPanel = useRootStore.use.openSlideoutPanel()
 	const setSelectedCounty = useRootStore.use.setSelectedCounty()
 	const setRegionHazards = useRootStore.use.setRegionHazards()
 	const selectedRegion = useRootStore.use.selectedRegion()
 	const regionHazards = useRootStore.use.regionHazards()
+
+	// Hazard filter state from store (for sidebar hover interaction)
+	const isHazardVisible = useRootStore.use.isHazardVisible()
+	const anyActiveOrToggledHazards = useRootStore.use.anyActiveOrToggledHazards()
 
 	const [frames, setFrames] = useState<MapFrame[]>([])
 	const [mapLayerVisibility, setMapLayerVisibility] = useState<Record<string, boolean>>({})
@@ -74,36 +80,49 @@ export const HazardsAnimator = ({ alerts }: HazardsAnimatorProps) => {
 	}, [selectedRegion])
 
 	// Convert regionHazards to MapFrame format
+	// Separates county alerts from coastal/offshore alerts
 	useEffect(() => {
 		if (!regionHazards || Object.keys(regionHazards).length === 0) {
 			setFrames([])
 			return
 		}
 
-		// Create GeoJSON features from regionHazards
-		const features = Object.entries(regionHazards).map(([countyId, data]: [string, any]) => {
-			const { shape, alerts: countyAlerts, properties } = data
-			const firstAlert = countyAlerts[0]
+		// Convert HEX color to RGBA array
+		const hexToRgba = (hex: string): [number, number, number, number] => {
+			const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+			if (result) {
+				return [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16), 255]
+			}
+			return [128, 128, 128, 255]
+		}
+
+		// Helper to check if an ID is a coastal/offshore region
+		// Coastal IDs typically start with letters (e.g., "ANZ", "AMZ", "GMZ", "PKZ", "PHZ", "PMZ", "PZZ", "LSZ", "LEZ", "LMZ", "LOZ", "LHZ", "LCZ", "SLZ")
+		// County IDs are numeric FIPS codes (e.g., "53073")
+		const isCoastalId = (id: string): boolean => {
+			// If ID starts with a letter, it's likely a coastal/offshore zone
+			return /^[A-Za-z]/.test(id)
+		}
+
+		const countyFeatures: any[] = []
+		const coastalFeatures: any[] = []
+
+		// Create GeoJSON features from regionHazards, separating counties from coastal
+		Object.entries(regionHazards).forEach(([regionId, data]: [string, any]) => {
+			const { shape, alerts: regionAlerts, properties } = data
+			const firstAlert = regionAlerts[0]
 			const alertColor = firstAlert?.hazardInfo?.color?.HEX || '#808080'
 
-			// Convert HEX color to RGBA array
-			const hexToRgba = (hex: string): [number, number, number, number] => {
-				const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
-				if (result) {
-					return [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16), 255]
-				}
-				return [128, 128, 128, 255]
-			}
-
-			return {
+			const feature = {
 				type: 'Feature' as const,
 				geometry: shape.geometry,
 				properties: {
 					...properties,
-					id: countyId,
+					id: regionId,
+					ID: regionId, // Include both formats for compatibility
 					alertColor: hexToRgba(alertColor),
 					hasAlert: true,
-					alerts: countyAlerts.map((alert: any) => ({
+					alerts: regionAlerts.map((alert: any) => ({
 						...alert,
 						event: alert.event,
 						headline: alert.headline,
@@ -113,19 +132,33 @@ export const HazardsAnimator = ({ alerts }: HazardsAnimatorProps) => {
 					})),
 				},
 			}
+
+			if (isCoastalId(regionId)) {
+				coastalFeatures.push(feature)
+			} else {
+				countyFeatures.push(feature)
+			}
 		})
 
-		const geoJSON = {
+		const countyGeoJSON = {
 			type: 'FeatureCollection' as const,
-			features,
+			features: countyFeatures,
+		}
+
+		const coastalGeoJSON = {
+			type: 'FeatureCollection' as const,
+			features: coastalFeatures,
 		}
 
 		const frame: MapFrame = {
 			id: 'current-hazards',
 			timestamp: new Date(),
-			data: geoJSON,
+			data: countyGeoJSON,
+			coastalData: coastalFeatures.length > 0 ? coastalGeoJSON : undefined,
 			metadata: {
-				alertCount: features.length,
+				alertCount: countyFeatures.length + coastalFeatures.length,
+				countyAlerts: countyFeatures.length,
+				coastalAlerts: coastalFeatures.length,
 				region: selectedRegion,
 			},
 		}
@@ -147,6 +180,32 @@ export const HazardsAnimator = ({ alerts }: HazardsAnimatorProps) => {
 	const handleMapZoomStateChange = useCallback((newZoomState: mapZoomState) => {
 		setTargetZoomState(newZoomState)
 	}, [])
+
+	// Hazard opacity function for sidebar hover interaction
+	// Returns 1 (full opacity) if county should be visible, 0.2 (dimmed) otherwise
+	const hazardOpacityFn = useCallback(
+		(countyAlerts: any[]): number => {
+			// If no filters are active, show all counties at full opacity
+			if (anyActiveOrToggledHazards()) {
+				return 1
+			}
+
+			// Check if any of the county's alerts match the active filter
+			if (countyAlerts && countyAlerts.length > 0) {
+				for (const alert of countyAlerts) {
+					const hazardType = alert.hazardType || alert.hazardInfo?.type?.type
+					const hazardLevel = alert.hazardLevel || alert.hazardInfo?.level?.level
+					if (hazardType && hazardLevel && isHazardVisible(hazardType, hazardLevel)) {
+						return 1 // Full opacity - this county has a matching alert
+					}
+				}
+			}
+
+			// No matching alerts - dim the county
+			return 0.2
+		},
+		[anyActiveOrToggledHazards, isHazardVisible],
+	)
 
 	// Layer configuration for hazards display
 	// Based on COUNTY_ALERTS preset but with CWA zones explicitly disabled
@@ -189,6 +248,8 @@ export const HazardsAnimator = ({ alerts }: HazardsAnimatorProps) => {
 				initialMapZoomState={targetZoomState}
 				setMapZoomState={handleMapZoomStateChange}
 				disableCwaDetection={true}
+				hazardOpacityFn={hazardOpacityFn}
+				allCoastalRegions={allCoastalRegions}
 			/>
 		</div>
 	)

--- a/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
+++ b/src/components/elements/HazardsAnimator/HazardsAnimator.tsx
@@ -6,14 +6,13 @@ import { MapFrame } from '@/components/elements/Animator/AnimatorMapMachine/type
 import { DATA_TEXT_HAZARDS_MAP_DETAILS_SLIDEOUT } from '@/data/vars'
 import { useRootStore } from '@/store/useRootStore'
 import { mapZoomState } from '@/types/general'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styles from './HazardsAnimator.module.scss'
 
 // Region view state configurations for different geographic regions
-// Note: Zoom must be > 4.5 for counties to show in AnimatorMapMachine
 const REGION_VIEW_STATES: Record<string, mapZoomState> = {
-	conus: { zoom: 4.6, latitude: 39.8283, longitude: -98.5795 },
-	ak: { zoom: 4.6, latitude: 64.2, longitude: -152 },
+	conus: { zoom: 3.8, latitude: 39.8283, longitude: -98.5795 },
+	ak: { zoom: 4.2, latitude: 64.2, longitude: -152 },
 	hi: { zoom: 6, latitude: 20.5, longitude: -157 },
 	pr: { zoom: 8, latitude: 18.21, longitude: -66 },
 	sam: { zoom: 8, latitude: -14.27, longitude: -170.7 },
@@ -28,6 +27,29 @@ const REGION_NAME_MAP: Record<string, string> = {
 	pr: 'Puerto Rico',
 	sam: 'American Samoa',
 	gum: 'Guam',
+}
+
+// Bounding boxes for region detection [minLat, maxLat, minLon, maxLon]
+const REGION_BOUNDS: Record<string, [number, number, number, number]> = {
+	conus: [24, 50, -125, -66],
+	ak: [51, 72, -180, -129],
+	hi: [18, 23, -161, -154],
+	pr: [17, 19, -68, -65],
+	sam: [-15, -13, -172, -169],
+	gum: [12, 15, 143, 146],
+}
+
+/**
+ * Detect which region the map center is in based on lat/lon
+ * Returns the region code or null if not in any defined region
+ */
+const detectRegionFromPosition = (latitude: number, longitude: number): string | null => {
+	for (const [regionCode, [minLat, maxLat, minLon, maxLon]] of Object.entries(REGION_BOUNDS)) {
+		if (latitude >= minLat && latitude <= maxLat && longitude >= minLon && longitude <= maxLon) {
+			return regionCode
+		}
+	}
+	return null
 }
 
 interface HazardsAnimatorProps {
@@ -51,6 +73,7 @@ export const HazardsAnimator = ({ alerts, allCoastalRegions }: HazardsAnimatorPr
 	const setSelectedCounty = useRootStore.use.setSelectedCounty()
 	const setRegionHazards = useRootStore.use.setRegionHazards()
 	const selectedRegion = useRootStore.use.selectedRegion()
+	const setSelectedRegion = useRootStore.use.setSelectedRegion()
 	const regionHazards = useRootStore.use.regionHazards()
 
 	// Hazard filter state from store (for sidebar hover interaction)
@@ -60,6 +83,9 @@ export const HazardsAnimator = ({ alerts, allCoastalRegions }: HazardsAnimatorPr
 	const [frames, setFrames] = useState<MapFrame[]>([])
 	const [mapLayerVisibility, setMapLayerVisibility] = useState<Record<string, boolean>>({})
 	const [targetZoomState, setTargetZoomState] = useState<mapZoomState | undefined>(REGION_VIEW_STATES.conus)
+
+	// Track whether region change was triggered by panning (to prevent zoom animation)
+	const regionChangeFromPanRef = useRef(false)
 
 	// Update region hazards when alerts or selected region changes
 	useEffect(() => {
@@ -71,8 +97,13 @@ export const HazardsAnimator = ({ alerts, allCoastalRegions }: HazardsAnimatorPr
 		}
 	}, [selectedRegion, alerts, setRegionHazards])
 
-	// Update zoom state when region changes
+	// Update zoom state when region changes (only if not triggered by panning)
 	useEffect(() => {
+		if (regionChangeFromPanRef.current) {
+			// Region change was triggered by panning - don't animate
+			regionChangeFromPanRef.current = false
+			return
+		}
 		const viewState = REGION_VIEW_STATES[selectedRegion]
 		if (viewState) {
 			setTargetZoomState(viewState)
@@ -177,9 +208,19 @@ export const HazardsAnimator = ({ alerts, allCoastalRegions }: HazardsAnimatorPr
 	)
 
 	// Handle zoom state updates from map interactions
-	const handleMapZoomStateChange = useCallback((newZoomState: mapZoomState) => {
-		setTargetZoomState(newZoomState)
-	}, [])
+	// Also detects when user pans to a different region and auto-switches data
+	const handleMapZoomStateChange = useCallback(
+		(newZoomState: mapZoomState) => {
+			// Detect if user has panned to a different region
+			const detectedRegion = detectRegionFromPosition(newZoomState.latitude, newZoomState.longitude)
+			if (detectedRegion && detectedRegion !== selectedRegion) {
+				// Mark that this region change is from panning (to prevent zoom animation)
+				regionChangeFromPanRef.current = true
+				setSelectedRegion(detectedRegion)
+			}
+		},
+		[selectedRegion, setSelectedRegion],
+	)
 
 	// Hazard opacity function for sidebar hover interaction
 	// Returns 1 (full opacity) if county should be visible, 0.2 (dimmed) otherwise

--- a/src/components/elements/HazardsAnimator/index.ts
+++ b/src/components/elements/HazardsAnimator/index.ts
@@ -1,0 +1,2 @@
+export { HazardsAnimator } from './HazardsAnimator'
+


### PR DESCRIPTION
## Monday.com Item

Monday Item ID: 10670595174

## Description

This PR updates the WFO (Weather Forecast Office) Active Hazards page to use the Deck.gl-based AnimatorMapMachine instead of the legacy D3/SVG-based HazardsMap component. The new implementation provides better performance, smoother interactions, and consistent behavior with other map-based animators in the platform.

**Key changes:**

- Created HazardsAnimator wrapper component that connects the Animator to the hazards store
- Added hazard opacity filtering for sidebar hover interaction (dim/highlight counties based on selected hazard types/levels)
- Fixed layer toggle issues: separated coastal and county alerts into individual data layers, fixed inactive region borders, and corrected lat/long grid toggle
- Implemented auto-region detection when panning between geographic regions (CONUS, Alaska, Hawaii, PR, Samoa, Guam)
- Integrated fullscreen toggle into ViewControls for seamless UI consistency
- Adjusted zoom levels for better default views (CONUS zoomed out more)

## How Has This Been Tested?

- Verified map renders with county and coastal region alerts colored correctly
- Tested layer toggles: inactive counties, inactive coastal regions, county alerts data layer, coastal alerts data layer, lat/long grid
- Tested region switching via dropdown and verified auto-region detection when panning between regions
- Tested fullscreen toggle shows/hides navigation and sidebar
- Tested sidebar hover interaction dims non-matching hazard counties
- Tested county click opens slideout panel with alert details

## Screenshots/GIF (if appropriate):

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)