### PR TITLE
Fix Convective Watches Page

### DIFF
--- a/src/components/blocks/ConvectiveWatchesPage/ConvectiveWatchesPage.tsx
+++ b/src/components/blocks/ConvectiveWatchesPage/ConvectiveWatchesPage.tsx
@@ -14,14 +14,14 @@ interface ConvectiveWatch {
 	time_begin: string
 	time_end: string
 	states: string[]
-	attributes: {
+	attributes?: {
 		'MAX HAIL /INCHES/'?: string
 		'MAX TOPS /X 100 FEET/'?: string
 		'MAX WIND GUSTS SURFACE /KNOTS/'?: string
 		'MEAN STORM MOTION VECTOR /DEGREES AND KNOTS/'?: string
 		'PARTICULARLY DANGEROUS SITUATION'?: string
 	}
-	probabilities: {
+	probabilities?: {
 		'PROB OF 1 OR MORE HAIL EVENTS >= 2 INCHES'?: string
 		'PROB OF 1 OR MORE STRONG /EF2-EF5/ TORNADOES'?: string
 		'PROB OF 1 OR MORE WIND EVENTS >= 65 KNOTS'?: string
@@ -41,11 +41,38 @@ export const ConvectiveWatchesPage = () => {
 		const fetchWatches = async () => {
 			try {
 				const data = await getConvectiveWatches()
-				if (data && Array.isArray(data)) {
-					setWatches(data)
+
+				// Validate response is an array
+				if (!Array.isArray(data)) {
+					console.error('getConvectiveWatches returned non-array data:', { dataType: typeof data })
+					setWatches([])
+					return
 				}
+
+				// Validate and filter each watch entry
+				const validWatches = data.filter((watch, index) => {
+					// Check required fields
+					if (!watch.number || !watch.watch_type) {
+						console.warn(`Watch at index ${index} missing required fields:`, { watch })
+						return false
+					}
+
+					// Log if attributes are missing
+					if (!watch.attributes) {
+						console.warn(`Watch ${watch.number} has missing or null attributes`, { watch })
+					}
+
+					return true
+				})
+
+				if (validWatches.length < data.length) {
+					console.warn(`Filtered ${data.length - validWatches.length} invalid watches from response`)
+				}
+
+				setWatches(validWatches)
 			} catch (error) {
 				console.error('Failed to fetch convective watches:', error)
+				setWatches([])
 			} finally {
 				setLoading(false)
 			}

--- a/src/components/elements/WatchSummaryCard/WatchSummaryCard.tsx
+++ b/src/components/elements/WatchSummaryCard/WatchSummaryCard.tsx
@@ -20,8 +20,8 @@ interface WatchSummaryCardProps {
 	timeBegin: string
 	timeEnd: string
 	states: string[]
-	attributes: WatchAttributes
-	probabilities: WatchProbabilities
+	attributes?: WatchAttributes
+	probabilities?: WatchProbabilities
 	graphic: string
 }
 
@@ -36,6 +36,10 @@ export const WatchSummaryCard = ({
 	probabilities,
 	graphic,
 }: WatchSummaryCardProps) => {
+	// Guard against null/undefined attributes with detailed logging
+	if (!attributes) {
+		console.warn(`Watch ${number} has null or undefined attributes. Expected attributes object.`, { attributes })
+	}
 	const decodedAttributes = decodeAttributes(attributes)
 	const router = useRouter()
 
@@ -89,7 +93,7 @@ export const WatchSummaryCard = ({
 					</div>
 				</div>
 
-				{Object.keys(probabilities).length > 0 && (
+				{probabilities && Object.keys(probabilities).length > 0 && (
 					<div className={styles.probabilitiesSection}>
 						<div className={styles.sectionTitle}>Probabilities</div>
 						<div className={styles.probsList}>

--- a/src/util/text/convective/watch-functions.ts
+++ b/src/util/text/convective/watch-functions.ts
@@ -32,8 +32,14 @@ export function getTypeClass(watchType?: string, notActive?: boolean, styles?: R
  * @param attributes - Raw attribute values from API
  * @returns Object mapping attribute IDs to { value: string, isHighThreshold: boolean }
  */
-export function decodeAttributes(attributes: WatchAttributes): Record<string, { value: string; isHighThreshold: boolean }> {
+export function decodeAttributes(attributes: WatchAttributes | null | undefined): Record<string, { value: string; isHighThreshold: boolean }> {
 	const decoded: Record<string, { value: string; isHighThreshold: boolean }> = {}
+
+	// Guard clause: return empty object if attributes is null or undefined
+	if (!attributes) {
+		console.warn('decodeAttributes called with null or undefined attributes')
+		return decoded
+	}
 
 	// Max Hail (threshold: 2)
 	if (attributes[ATTR_MAX_HAIL]) {


### PR DESCRIPTION
<!--- Reference a Monday issue and provide a general summary -->
<!--- of your changes in the Title above -->

## Monday.com Item

Monday Item ID: 11498892930

## Description
At some point, the convective watches page started throwing errors on load for `null` attributes in spite of the fact that the endpoint being fetched contained zero null `attributes` fields. So error handling was put in place and some properties were made conditional (not required).

<!--- Describe your changes in detail, motivation and context -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run dev` no errors locally. Will check vercel build.

<!--- Please describe how you tested your changes. -->
<!--- Include steps or any other methods for an engineer to reproduce your test.-->
<!--- Include details of your testing environment, tests ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/GIF (if appropriate):

## Types of changes

<!--- What gql of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
